### PR TITLE
feat: add verbose mode for detailed operation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ npx cdk-agc
 # Dry-run: Preview what would be deleted
 npx cdk-agc -d
 
+# Verbose: Show detailed operation information
+npx cdk-agc -v
+
 # Custom directory (useful for monorepos)
 npx cdk-agc -o ./packages/infra/cdk.out
 
@@ -78,6 +81,7 @@ npx cdk-agc -t
 | --------------------------- | --------------------------------------------------- | --------- |
 | `-o, --outdir <path>`       | CDK output directory to clean                       | `cdk.out` |
 | `-d, --dry-run`             | Show what would be deleted without deleting         | `false`   |
+| `-v, --verbose`             | Show detailed operation information                 | `false`   |
 | `-k, --keep-hours <number>` | Protect files modified within N hours               | `0`       |
 | `-t, --cleanup-tmp`         | Clean up all temporary CDK directories in `$TMPDIR` | `false`   |
 | `-h, --help`                | Display help                                        |           |

--- a/src/asset-cleanup.test.ts
+++ b/src/asset-cleanup.test.ts
@@ -718,4 +718,164 @@ describe("cleanupAssets", () => {
 
     consoleLogSpy.mockRestore();
   });
+
+  it("should correctly filter protected and unprotected assets", async () => {
+    await createTestManifest();
+
+    // Create referenced asset (should be protected)
+    await createTestFile("asset.referenced/file.txt", "referenced");
+
+    // Create old unreferenced asset (should be deleted with keep-hours=0)
+    await createTestFile("asset.old/file.txt", "old");
+
+    // Reference one asset
+    const assetsJson = {
+      version: "1.0",
+      files: {
+        file1: {
+          source: { path: "asset.referenced" },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+    // Run cleanup with keep-hours=0 (only referenced assets protected)
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+    // Verify: referenced should exist, old should be deleted
+    expect(await fileExists("asset.referenced")).toBe(true);
+    expect(await fileExists("asset.old")).toBe(false);
+  });
+
+  it("should handle multiple protection reasons correctly", async () => {
+    await createTestManifest();
+
+    // Create asset that is both referenced AND recent
+    await createTestFile("asset.both/file.txt", "both protected");
+
+    // Create asset that is only referenced
+    await createTestFile("asset.onlyref/file.txt", "only referenced");
+
+    // Reference both assets
+    const assetsJson = {
+      version: "1.0",
+      files: {
+        file1: {
+          source: { path: "asset.both" },
+          destinations: {},
+        },
+        file2: {
+          source: { path: "asset.onlyref" },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+    // Run with verbose to check protection reason
+    const consoleLogSpy = vi.spyOn(console, "log");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 24, verbose: true });
+
+    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    // Both should show "referenced in *.assets.json" as the reason
+    // (referenced takes precedence over recent in our implementation)
+    expect(logOutput).toContain("asset.both");
+    expect(logOutput).toContain("asset.onlyref");
+    expect(logOutput).toContain("referenced in *.assets.json");
+
+    // Both assets should still exist
+    expect(await fileExists("asset.both")).toBe(true);
+    expect(await fileExists("asset.onlyref")).toBe(true);
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should correctly map filtered results to deletion candidates", async () => {
+    await createTestManifest();
+
+    // Create mix of assets
+    await createTestFile("asset.delete1/file.txt", "delete1");
+    await createTestFile("asset.delete2/file.txt", "delete2");
+    await createTestFile("asset.delete3/file.txt", "delete3");
+    await createTestFile("asset.protected/file.txt", "protected");
+
+    // Reference only one
+    const assetsJson = {
+      version: "1.0",
+      files: {
+        file1: {
+          source: { path: "asset.protected" },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+    // Verify the filter/map worked correctly: 3 deleted, 1 protected
+    expect(await fileExists("asset.delete1")).toBe(false);
+    expect(await fileExists("asset.delete2")).toBe(false);
+    expect(await fileExists("asset.delete3")).toBe(false);
+    expect(await fileExists("asset.protected")).toBe(true);
+  });
+
+  it("should handle empty asset list correctly", async () => {
+    await createTestManifest();
+
+    // No assets at all, just manifest
+    const consoleLogSpy = vi.spyOn(console, "log");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
+
+    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    // Should show 0 assets found
+    expect(logOutput).toContain("Found 0 total asset file(s)/directory(ies)");
+    expect(logOutput).toContain("No unused assets found");
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should handle all assets being protected", async () => {
+    await createTestManifest();
+
+    // Create only referenced assets
+    await createTestFile("asset.ref1/file.txt", "ref1");
+    await createTestFile("asset.ref2/file.txt", "ref2");
+
+    const assetsJson = {
+      version: "1.0",
+      files: {
+        file1: {
+          source: { path: "asset.ref1" },
+          destinations: {},
+        },
+        file2: {
+          source: { path: "asset.ref2" },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+    const consoleLogSpy = vi.spyOn(console, "log");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
+
+    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    // Should show all protected, no unused assets
+    expect(logOutput).toContain("Protected assets:");
+    expect(logOutput).toContain("No unused assets found");
+
+    // All should still exist
+    expect(await fileExists("asset.ref1")).toBe(true);
+    expect(await fileExists("asset.ref2")).toBe(true);
+
+    consoleLogSpy.mockRestore();
+  });
 });

--- a/src/asset-cleanup.test.ts
+++ b/src/asset-cleanup.test.ts
@@ -691,7 +691,9 @@ describe("cleanupAssets", () => {
 
     expect(logOutput).toContain("Collecting referenced assets from *.assets.json files...");
     expect(logOutput).toContain("Found 1 asset(s) referenced in *.assets.json files");
-    expect(logOutput).toContain('Found 3 total asset file(s)/directory(ies) (starting with "asset.")');
+    expect(logOutput).toContain(
+      'Found 3 total asset file(s)/directory(ies) (starting with "asset.")',
+    );
     expect(logOutput).toContain("Analyzing assets for deletion candidates...");
 
     consoleLogSpy.mockRestore();

--- a/src/asset-cleanup.test.ts
+++ b/src/asset-cleanup.test.ts
@@ -138,527 +138,535 @@ describe("cleanupAssets", () => {
     expect(await fileExists("asset.unused/file.txt")).toBe(true);
   });
 
-  it("should protect recent files based on keepHours", async () => {
-    await createTestManifest();
-    await createTestFile("asset.recent/file.txt", "new file");
-    // Wait a bit to ensure mtime is set
-    await new Promise((resolve) => setTimeout(resolve, 100));
+  describe("keepHours option", () => {
+    it("should protect recent files based on keepHours", async () => {
+      await createTestManifest();
+      await createTestFile("asset.recent/file.txt", "new file");
+      // Wait a bit to ensure mtime is set
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 1 });
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 1 });
 
-    expect(await fileExists("asset.recent/file.txt")).toBe(true);
-  });
+      expect(await fileExists("asset.recent/file.txt")).toBe(true);
+    });
 
-  it("should protect nested stack template files", async () => {
-    await createTestManifest();
-    await createTestFile("CdkSampleStack.template.json", "{}");
-    await createTestFile("CdkSampleStack.assets.json", "{}");
-    await createTestFile("CdkSampleStackMyNestedStackEC13F2A2.nested.template.json", "{}");
-    await createTestFile("asset.unused-dir/file.txt", "delete me");
+    it("should protect nested stack template files", async () => {
+      await createTestManifest();
+      await createTestFile("CdkSampleStack.template.json", "{}");
+      await createTestFile("CdkSampleStack.assets.json", "{}");
+      await createTestFile("CdkSampleStackMyNestedStackEC13F2A2.nested.template.json", "{}");
+      await createTestFile("asset.unused-dir/file.txt", "delete me");
 
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
 
-    expect(await fileExists("CdkSampleStack.template.json")).toBe(true);
-    expect(await fileExists("CdkSampleStack.assets.json")).toBe(true);
-    expect(await fileExists("CdkSampleStackMyNestedStackEC13F2A2.nested.template.json")).toBe(true);
-    expect(await fileExists("asset.unused-dir")).toBe(false);
-  });
+      expect(await fileExists("CdkSampleStack.template.json")).toBe(true);
+      expect(await fileExists("CdkSampleStack.assets.json")).toBe(true);
+      expect(await fileExists("CdkSampleStackMyNestedStackEC13F2A2.nested.template.json")).toBe(
+        true,
+      );
+      expect(await fileExists("asset.unused-dir")).toBe(false);
+    });
 
-  it("should delete unreferenced file assets (not just directories)", async () => {
-    await createTestManifest();
+    it("should delete unreferenced file assets (not just directories)", async () => {
+      await createTestManifest();
 
-    // Create assets.json with a reference to a file asset
-    const assetsJson = {
-      version: "1.0.0",
-      files: {
-        referencedFile: {
-          source: {
-            path: "asset.referenced-file.txt",
-            packaging: "file",
+      // Create assets.json with a reference to a file asset
+      const assetsJson = {
+        version: "1.0.0",
+        files: {
+          referencedFile: {
+            source: {
+              path: "asset.referenced-file.txt",
+              packaging: "file",
+            },
+            destinations: {},
           },
-          destinations: {},
         },
-      },
-    };
-    await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
+      };
+      await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
 
-    await createTestFile("asset.referenced-file.txt", "keep me");
-    await createTestFile("asset.unreferenced-file.txt", "delete me");
+      await createTestFile("asset.referenced-file.txt", "keep me");
+      await createTestFile("asset.unreferenced-file.txt", "delete me");
 
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
 
-    expect(await fileExists("asset.referenced-file.txt")).toBe(true);
-    expect(await fileExists("asset.unreferenced-file.txt")).toBe(false);
-  });
+      expect(await fileExists("asset.referenced-file.txt")).toBe(true);
+      expect(await fileExists("asset.unreferenced-file.txt")).toBe(false);
+    });
 
-  it("should throw error if directory does not exist", async () => {
-    await expect(
-      cleanupAssets({ outdir: "/non-existent-dir", dryRun: false, keepHours: 0 }),
-    ).rejects.toThrow("Directory not found");
-  });
+    describe("edge cases", () => {
+      it("should throw error if directory does not exist", async () => {
+        await expect(
+          cleanupAssets({ outdir: "/non-existent-dir", dryRun: false, keepHours: 0 }),
+        ).rejects.toThrow("Directory not found");
+      });
 
-  it("should handle empty directory gracefully", async () => {
-    await createTestManifest();
+      it("should handle empty directory gracefully", async () => {
+        await createTestManifest();
 
-    await expect(
-      cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 }),
-    ).resolves.not.toThrow();
-  });
+        await expect(
+          cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 }),
+        ).resolves.not.toThrow();
+      });
 
-  it("should protect assets used by multiple stacks", async () => {
-    await createTestManifest();
+      it("should protect assets used by multiple stacks", async () => {
+        await createTestManifest();
 
-    // Create two stacks that share the same asset
-    const stack1AssetsJson = {
-      version: "1.0.0",
-      files: {
-        shared123: {
-          source: {
-            path: "asset.shared123",
-            packaging: "zip",
-          },
-          destinations: {},
-        },
-        stack1only: {
-          source: {
-            path: "asset.stack1only",
-            packaging: "file",
-          },
-          destinations: {},
-        },
-      },
-    };
-
-    const stack2AssetsJson = {
-      version: "1.0.0",
-      files: {
-        shared123: {
-          source: {
-            path: "asset.shared123",
-            packaging: "zip",
-          },
-          destinations: {},
-        },
-        stack2only: {
-          source: {
-            path: "asset.stack2only",
-            packaging: "file",
-          },
-          destinations: {},
-        },
-      },
-    };
-
-    await createTestFile("Stack1.assets.json", JSON.stringify(stack1AssetsJson, null, 2));
-    await createTestFile("Stack2.assets.json", JSON.stringify(stack2AssetsJson, null, 2));
-
-    // Create asset directories
-    await createTestFile("asset.shared123/index.js", "console.log('shared')");
-    await createTestFile("asset.stack1only/data1.json", '{"stack":1}');
-    await createTestFile("asset.stack2only/data2.json", '{"stack":2}');
-    await createTestFile("asset.unused/old.txt", "delete me");
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-    // Shared asset should be protected
-    expect(await fileExists("asset.shared123/index.js")).toBe(true);
-
-    // Stack-specific assets should be protected
-    expect(await fileExists("asset.stack1only/data1.json")).toBe(true);
-    expect(await fileExists("asset.stack2only/data2.json")).toBe(true);
-
-    // Unreferenced asset should be deleted
-    expect(await fileExists("asset.unused")).toBe(false);
-  });
-
-  it("should protect unreferenced assets with --keep-hours", async () => {
-    await createTestManifest();
-
-    // Create an assets.json file with one reference
-    const assetsJson = {
-      version: "1.0.0",
-      files: {
-        referenced: {
-          source: {
-            path: "asset.referenced",
-            packaging: "zip",
-          },
-          destinations: {},
-        },
-      },
-    };
-
-    await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
-
-    // Create referenced and unreferenced assets
-    await createTestFile("asset.referenced/index.js", "console.log('referenced')");
-    await createTestFile("asset.recent-unreferenced/index.js", "console.log('recent')");
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 1 });
-
-    // Referenced asset should be protected
-    expect(await fileExists("asset.referenced/index.js")).toBe(true);
-
-    // Recent unreferenced asset should be protected by keepHours
-    expect(await fileExists("asset.recent-unreferenced/index.js")).toBe(true);
-  });
-
-  it("should not delete user files (non-asset files)", async () => {
-    await createTestManifest();
-
-    // Create an assets.json file
-    const assetsJson = {
-      version: "1.0.0",
-      files: {
-        referenced: {
-          source: {
-            path: "asset.referenced",
-            packaging: "zip",
-          },
-          destinations: {},
-        },
-      },
-    };
-
-    await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
-
-    // Create CDK-generated asset
-    await createTestFile("asset.referenced/index.js", "console.log('referenced')");
-
-    // Create user files that should NOT be deleted
-    await createTestFile("my-notes.txt", "User notes");
-    await createTestFile("debug.log", "Debug log");
-    await createTestFile("temp-data/data.json", '{"test":true}');
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-    // Referenced asset should be protected
-    expect(await fileExists("asset.referenced/index.js")).toBe(true);
-
-    // User files should NOT be deleted
-    expect(await fileExists("my-notes.txt")).toBe(true);
-    expect(await fileExists("debug.log")).toBe(true);
-    expect(await fileExists("temp-data/data.json")).toBe(true);
-  });
-
-  it("should handle negative keepHours (treat as 0)", async () => {
-    await createTestManifest();
-    await createTestFile("asset.old/file.txt", "old file");
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: -1 });
-
-    // Negative value should be treated as no time-based protection
-    expect(await fileExists("asset.old")).toBe(false);
-  });
-
-  it("should handle very large keepHours value", async () => {
-    await createTestManifest();
-    await createTestFile("asset.recent/file.txt", "recent file");
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 99999 });
-
-    // Very large value should protect all recent files
-    expect(await fileExists("asset.recent/file.txt")).toBe(true);
-  });
-
-  it("should handle fractional keepHours value", async () => {
-    await createTestManifest();
-    await createTestFile("asset.verynew/file.txt", "very new file");
-
-    // 0.001 hours = 3.6 seconds
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0.001 });
-
-    // File created just now should be protected
-    expect(await fileExists("asset.verynew/file.txt")).toBe(true);
-  });
-
-  it("should delete assets older than keepHours and protect newer ones", async () => {
-    await createTestManifest();
-
-    // Create assets with different ages
-    const oldAssetPath = path.join(TEST_DIR, "asset.old");
-    const newAssetPath = path.join(TEST_DIR, "asset.new");
-    const boundaryAssetPath = path.join(TEST_DIR, "asset.boundary");
-
-    await fs.mkdir(oldAssetPath, { recursive: true });
-    await fs.writeFile(path.join(oldAssetPath, "file.txt"), "old content");
-
-    await fs.mkdir(newAssetPath, { recursive: true });
-    await fs.writeFile(path.join(newAssetPath, "file.txt"), "new content");
-
-    await fs.mkdir(boundaryAssetPath, { recursive: true });
-    await fs.writeFile(path.join(boundaryAssetPath, "file.txt"), "boundary content");
-
-    // Set modification times relative to when cleanup will run
-    // Add buffer to account for test execution time
-    const now = Date.now();
-    const fourHoursAgo = now - 4 * 60 * 60 * 1000; // 4 hours ago
-    const twoHoursAgo = now - 2 * 60 * 60 * 1000; // 2 hours ago
-    const threeHoursAgo = now - 3 * 60 * 60 * 1000 + 100; // Just under 3 hours ago
-
-    await fs.utimes(oldAssetPath, new Date(fourHoursAgo), new Date(fourHoursAgo));
-    await fs.utimes(newAssetPath, new Date(twoHoursAgo), new Date(twoHoursAgo));
-    await fs.utimes(boundaryAssetPath, new Date(threeHoursAgo), new Date(threeHoursAgo));
-
-    // Clean with keepHours: 3
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 3 });
-
-    // Asset older than 3 hours should be deleted
-    expect(await fileExists("asset.old")).toBe(false);
-
-    // Asset newer than 3 hours should be protected
-    expect(await fileExists("asset.new")).toBe(true);
-
-    // Asset exactly at 3 hours boundary should be protected (<=)
-    expect(await fileExists("asset.boundary")).toBe(true);
-  });
-
-  it("should protect assets referenced in nested assembly directories", async () => {
-    await createTestManifest();
-
-    // Create nested assembly directory structure
-    await createTestFile("assembly-MyStage/cdk.out", "");
-    await createTestFile("assembly-MyStage/manifest.json", "{}");
-    await createTestFile("assembly-MyStage/MyStageCdkSampleStackC627666C.template.json", "{}");
-
-    // Create assets.json in nested assembly that references top-level asset with relative path
-    const nestedAssetsJson = {
-      version: "1.0.0",
-      files: {
-        asset1: {
-          source: {
-            path: "../asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098",
-            packaging: "zip",
-          },
-          destinations: {},
-        },
-      },
-    };
-    await createTestFile(
-      "assembly-MyStage/MyStageCdkSampleStackC627666C.assets.json",
-      JSON.stringify(nestedAssetsJson, null, 2),
-    );
-
-    // Create assets at top level
-    await createTestFile(
-      "asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098/index.js",
-      "console.log('stage asset')",
-    );
-    await createTestFile("asset.unused/old.txt", "delete me");
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-    // Asset referenced in nested assembly should be protected
-    expect(await fileExists("assembly-MyStage/cdk.out")).toBe(true);
-    expect(await fileExists("assembly-MyStage/manifest.json")).toBe(true);
-    expect(await fileExists("assembly-MyStage/MyStageCdkSampleStackC627666C.template.json")).toBe(
-      true,
-    );
-    expect(await fileExists("assembly-MyStage/MyStageCdkSampleStackC627666C.assets.json")).toBe(
-      true,
-    );
-    expect(
-      await fileExists(
-        "asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098/index.js",
-      ),
-    ).toBe(true);
-
-    // Unreferenced asset should be deleted
-    expect(await fileExists("asset.unused")).toBe(false);
-  });
-
-  it("should delete Docker images when deleting Docker asset directories", async () => {
-    await createTestManifest();
-
-    const referencedHash = "f575bdffb1fb794e3010c609b768095d4f1d64e2dca5ce27938971210488a04d";
-    const assetsJson = {
-      version: "1.0.0",
-      dockerImages: {
-        [referencedHash]: {
-          source: {
-            directory: `asset.${referencedHash}`,
-          },
-          destinations: {
-            "123456789012-us-east-1-xxx": {
-              repositoryName: "cdk-hnb659fds-container-assets-123456789012-us-east-1",
-              imageTag: referencedHash,
-              region: "us-east-1",
+        // Create two stacks that share the same asset
+        const stack1AssetsJson = {
+          version: "1.0.0",
+          files: {
+            shared123: {
+              source: {
+                path: "asset.shared123",
+                packaging: "zip",
+              },
+              destinations: {},
+            },
+            stack1only: {
+              source: {
+                path: "asset.stack1only",
+                packaging: "file",
+              },
+              destinations: {},
             },
           },
-        },
-      },
-    };
+        };
 
-    await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
-
-    // Create referenced Docker asset
-    await createTestFile(`asset.${referencedHash}/Dockerfile`, "FROM node:24");
-
-    // Create unreferenced Docker asset
-    const unusedHash = "9ae778431447a6965dbd163b99646b5275c91c065727748fa16e8ccc29e9dd42";
-    await createTestFile(`asset.${unusedHash}/Dockerfile`, "FROM node:24");
-
-    // Mock collectDockerImageAssetPaths to identify Docker assets
-    const mockedCollectDockerImageAssetPaths = vi.mocked(
-      dockerCleanup.collectDockerImageAssetPaths,
-    );
-    mockedCollectDockerImageAssetPaths.mockResolvedValue(
-      new Set([
-        path.join(TEST_DIR, `asset.${referencedHash}`),
-        path.join(TEST_DIR, `asset.${unusedHash}`),
-      ]),
-    );
-
-    const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
-    mockedDeleteDockerImages.mockResolvedValue(0);
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-    // Referenced Docker asset should be protected
-    expect(await fileExists(`asset.${referencedHash}`)).toBe(true);
-
-    // Unreferenced Docker asset should be deleted
-    expect(await fileExists(`asset.${unusedHash}`)).toBe(false);
-
-    // deleteDockerImages should be called with unreferenced hash
-    expect(mockedDeleteDockerImages).toHaveBeenCalledTimes(1);
-    expect(mockedDeleteDockerImages).toHaveBeenCalledWith([unusedHash], false, undefined);
-  });
-
-  it("should show Docker images in dry-run mode", async () => {
-    await createTestManifest();
-
-    const dockerHash = "f575bdffb1fb794e3010c609b768095d4f1d64e2dca5ce27938971210488a04d";
-
-    // Create unreferenced Docker asset
-    await createTestFile(`asset.${dockerHash}/Dockerfile`, "FROM node:24");
-
-    // Mock collectDockerImageAssetPaths to identify Docker assets
-    const mockedCollectDockerImageAssetPaths = vi.mocked(
-      dockerCleanup.collectDockerImageAssetPaths,
-    );
-    mockedCollectDockerImageAssetPaths.mockResolvedValue(
-      new Set([path.join(TEST_DIR, `asset.${dockerHash}`)]),
-    );
-
-    const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
-    mockedDeleteDockerImages.mockResolvedValue(0);
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0 });
-
-    // Docker asset directory should NOT be deleted in dry-run mode
-    expect(await fileExists(`asset.${dockerHash}`)).toBe(true);
-
-    // deleteDockerImages should be called with dryRun=true
-    expect(mockedDeleteDockerImages).toHaveBeenCalledWith([dockerHash], true, undefined);
-  });
-
-  it("should not call deleteDockerImages for non-Docker assets", async () => {
-    await createTestManifest();
-
-    // Create unreferenced file asset (not Docker)
-    await createTestFile("asset.abc123/data.txt", "not docker");
-
-    // Mock collectDockerImageAssetPaths to return empty (no Docker assets)
-    const mockedCollectDockerImageAssetPaths = vi.mocked(
-      dockerCleanup.collectDockerImageAssetPaths,
-    );
-    mockedCollectDockerImageAssetPaths.mockResolvedValue(new Set());
-
-    const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-    // File asset should be deleted
-    expect(await fileExists("asset.abc123")).toBe(false);
-
-    // deleteDockerImages should not be called when there are no Docker assets
-    expect(mockedDeleteDockerImages).not.toHaveBeenCalled();
-  });
-
-  it("should only scan assembly-* directories to avoid infinite loops", async () => {
-    await createTestManifest();
-
-    // Create nested assembly-* directories (Stage nesting)
-    await createTestFile("assembly-Stage1/assembly-Stage2/cdk.out", "");
-    const nestedAssetsJson = {
-      version: "1.0.0",
-      files: {
-        nested: {
-          source: {
-            path: "../../asset.nested123",
-            packaging: "zip",
+        const stack2AssetsJson = {
+          version: "1.0.0",
+          files: {
+            shared123: {
+              source: {
+                path: "asset.shared123",
+                packaging: "zip",
+              },
+              destinations: {},
+            },
+            stack2only: {
+              source: {
+                path: "asset.stack2only",
+                packaging: "file",
+              },
+              destinations: {},
+            },
           },
-          destinations: {},
-        },
-      },
-    };
-    await createTestFile(
-      "assembly-Stage1/assembly-Stage2/Stack.assets.json",
-      JSON.stringify(nestedAssetsJson, null, 2),
-    );
+        };
 
-    // Create asset referenced by nested assembly
-    await createTestFile("asset.nested123/index.js", "console.log('nested')");
+        await createTestFile("Stack1.assets.json", JSON.stringify(stack1AssetsJson, null, 2));
+        await createTestFile("Stack2.assets.json", JSON.stringify(stack2AssetsJson, null, 2));
 
-    // Create unreferenced asset
-    await createTestFile("asset.unused/old.txt", "delete me");
+        // Create asset directories
+        await createTestFile("asset.shared123/index.js", "console.log('shared')");
+        await createTestFile("asset.stack1only/data1.json", '{"stack":1}');
+        await createTestFile("asset.stack2only/data2.json", '{"stack":2}');
+        await createTestFile("asset.unused/old.txt", "delete me");
 
-    // Create a non-assembly directory with assets.json that should be ignored (not scanned recursively)
-    const nonAssemblyAssetsJson = {
-      version: "1.0.0",
-      files: {
-        shouldBeIgnored: {
-          source: {
-            path: "../asset.shouldBeIgnored",
-            packaging: "zip",
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+        // Shared asset should be protected
+        expect(await fileExists("asset.shared123/index.js")).toBe(true);
+
+        // Stack-specific assets should be protected
+        expect(await fileExists("asset.stack1only/data1.json")).toBe(true);
+        expect(await fileExists("asset.stack2only/data2.json")).toBe(true);
+
+        // Unreferenced asset should be deleted
+        expect(await fileExists("asset.unused")).toBe(false);
+      });
+
+      it("should protect unreferenced assets with --keep-hours", async () => {
+        await createTestManifest();
+
+        // Create an assets.json file with one reference
+        const assetsJson = {
+          version: "1.0.0",
+          files: {
+            referenced: {
+              source: {
+                path: "asset.referenced",
+                packaging: "zip",
+              },
+              destinations: {},
+            },
           },
-          destinations: {},
+        };
+
+        await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
+
+        // Create referenced and unreferenced assets
+        await createTestFile("asset.referenced/index.js", "console.log('referenced')");
+        await createTestFile("asset.recent-unreferenced/index.js", "console.log('recent')");
+
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 1 });
+
+        // Referenced asset should be protected
+        expect(await fileExists("asset.referenced/index.js")).toBe(true);
+
+        // Recent unreferenced asset should be protected by keepHours
+        expect(await fileExists("asset.recent-unreferenced/index.js")).toBe(true);
+      });
+
+      it("should not delete user files (non-asset files)", async () => {
+        await createTestManifest();
+
+        // Create an assets.json file
+        const assetsJson = {
+          version: "1.0.0",
+          files: {
+            referenced: {
+              source: {
+                path: "asset.referenced",
+                packaging: "zip",
+              },
+              destinations: {},
+            },
+          },
+        };
+
+        await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
+
+        // Create CDK-generated asset
+        await createTestFile("asset.referenced/index.js", "console.log('referenced')");
+
+        // Create user files that should NOT be deleted
+        await createTestFile("my-notes.txt", "User notes");
+        await createTestFile("debug.log", "Debug log");
+        await createTestFile("temp-data/data.json", '{"test":true}');
+
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+        // Referenced asset should be protected
+        expect(await fileExists("asset.referenced/index.js")).toBe(true);
+
+        // User files should NOT be deleted
+        expect(await fileExists("my-notes.txt")).toBe(true);
+        expect(await fileExists("debug.log")).toBe(true);
+        expect(await fileExists("temp-data/data.json")).toBe(true);
+      });
+
+      it("should handle negative keepHours (treat as 0)", async () => {
+        await createTestManifest();
+        await createTestFile("asset.old/file.txt", "old file");
+
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: -1 });
+
+        // Negative value should be treated as no time-based protection
+        expect(await fileExists("asset.old")).toBe(false);
+      });
+
+      it("should handle very large keepHours value", async () => {
+        await createTestManifest();
+        await createTestFile("asset.recent/file.txt", "recent file");
+
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 99999 });
+
+        // Very large value should protect all recent files
+        expect(await fileExists("asset.recent/file.txt")).toBe(true);
+      });
+
+      it("should handle fractional keepHours value", async () => {
+        await createTestManifest();
+        await createTestFile("asset.verynew/file.txt", "very new file");
+
+        // 0.001 hours = 3.6 seconds
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0.001 });
+
+        // File created just now should be protected
+        expect(await fileExists("asset.verynew/file.txt")).toBe(true);
+      });
+
+      it("should delete assets older than keepHours and protect newer ones", async () => {
+        await createTestManifest();
+
+        // Create assets with different ages
+        const oldAssetPath = path.join(TEST_DIR, "asset.old");
+        const newAssetPath = path.join(TEST_DIR, "asset.new");
+        const boundaryAssetPath = path.join(TEST_DIR, "asset.boundary");
+
+        await fs.mkdir(oldAssetPath, { recursive: true });
+        await fs.writeFile(path.join(oldAssetPath, "file.txt"), "old content");
+
+        await fs.mkdir(newAssetPath, { recursive: true });
+        await fs.writeFile(path.join(newAssetPath, "file.txt"), "new content");
+
+        await fs.mkdir(boundaryAssetPath, { recursive: true });
+        await fs.writeFile(path.join(boundaryAssetPath, "file.txt"), "boundary content");
+
+        // Set modification times relative to when cleanup will run
+        // Add buffer to account for test execution time
+        const now = Date.now();
+        const fourHoursAgo = now - 4 * 60 * 60 * 1000; // 4 hours ago
+        const twoHoursAgo = now - 2 * 60 * 60 * 1000; // 2 hours ago
+        const threeHoursAgo = now - 3 * 60 * 60 * 1000 + 100; // Just under 3 hours ago
+
+        await fs.utimes(oldAssetPath, new Date(fourHoursAgo), new Date(fourHoursAgo));
+        await fs.utimes(newAssetPath, new Date(twoHoursAgo), new Date(twoHoursAgo));
+        await fs.utimes(boundaryAssetPath, new Date(threeHoursAgo), new Date(threeHoursAgo));
+
+        // Clean with keepHours: 3
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 3 });
+
+        // Asset older than 3 hours should be deleted
+        expect(await fileExists("asset.old")).toBe(false);
+
+        // Asset newer than 3 hours should be protected
+        expect(await fileExists("asset.new")).toBe(true);
+
+        // Asset exactly at 3 hours boundary should be protected (<=)
+        expect(await fileExists("asset.boundary")).toBe(true);
+      });
+    });
+
+    it("should protect assets referenced in nested assembly directories", async () => {
+      await createTestManifest();
+
+      // Create nested assembly directory structure
+      await createTestFile("assembly-MyStage/cdk.out", "");
+      await createTestFile("assembly-MyStage/manifest.json", "{}");
+      await createTestFile("assembly-MyStage/MyStageCdkSampleStackC627666C.template.json", "{}");
+
+      // Create assets.json in nested assembly that references top-level asset with relative path
+      const nestedAssetsJson = {
+        version: "1.0.0",
+        files: {
+          asset1: {
+            source: {
+              path: "../asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098",
+              packaging: "zip",
+            },
+            destinations: {},
+          },
         },
-      },
-    };
-    await createTestFile(
-      "non-assembly-dir/Stack.assets.json",
-      JSON.stringify(nonAssemblyAssetsJson, null, 2),
-    );
-    await createTestFile("asset.shouldBeIgnored/data.txt", "this should be deleted");
+      };
+      await createTestFile(
+        "assembly-MyStage/MyStageCdkSampleStackC627666C.assets.json",
+        JSON.stringify(nestedAssetsJson, null, 2),
+      );
 
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+      // Create assets at top level
+      await createTestFile(
+        "asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098/index.js",
+        "console.log('stage asset')",
+      );
+      await createTestFile("asset.unused/old.txt", "delete me");
 
-    // Asset referenced in nested assembly should be protected
-    expect(await fileExists("asset.nested123/index.js")).toBe(true);
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
 
-    // Unreferenced asset should be deleted
-    expect(await fileExists("asset.unused")).toBe(false);
+      // Asset referenced in nested assembly should be protected
+      expect(await fileExists("assembly-MyStage/cdk.out")).toBe(true);
+      expect(await fileExists("assembly-MyStage/manifest.json")).toBe(true);
+      expect(await fileExists("assembly-MyStage/MyStageCdkSampleStackC627666C.template.json")).toBe(
+        true,
+      );
+      expect(await fileExists("assembly-MyStage/MyStageCdkSampleStackC627666C.assets.json")).toBe(
+        true,
+      );
+      expect(
+        await fileExists(
+          "asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098/index.js",
+        ),
+      ).toBe(true);
 
-    // Asset referenced in non-assembly directory should be deleted (because non-assembly dirs are not scanned)
-    expect(await fileExists("asset.shouldBeIgnored")).toBe(false);
+      // Unreferenced asset should be deleted
+      expect(await fileExists("asset.unused")).toBe(false);
+    });
 
-    // Non-assembly directory itself should remain (only asset.* items are deletion candidates)
-    expect(await fileExists("non-assembly-dir/Stack.assets.json")).toBe(true);
-  });
+    describe("Docker image cleanup", () => {
+      it("should delete Docker images when deleting Docker asset directories", async () => {
+        await createTestManifest();
 
-  it("should handle broken symbolic links gracefully", async () => {
-    await createTestManifest();
+        const referencedHash = "f575bdffb1fb794e3010c609b768095d4f1d64e2dca5ce27938971210488a04d";
+        const assetsJson = {
+          version: "1.0.0",
+          dockerImages: {
+            [referencedHash]: {
+              source: {
+                directory: `asset.${referencedHash}`,
+              },
+              destinations: {
+                "123456789012-us-east-1-xxx": {
+                  repositoryName: "cdk-hnb659fds-container-assets-123456789012-us-east-1",
+                  imageTag: referencedHash,
+                  region: "us-east-1",
+                },
+              },
+            },
+          },
+        };
 
-    // Create an asset directory with a broken symlink
-    const assetDir = path.join(TEST_DIR, "asset.with-broken-symlink");
-    await fs.mkdir(assetDir, { recursive: true });
-    await fs.writeFile(path.join(assetDir, "normal-file.txt"), "normal content");
+        await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
 
-    // Create broken symbolic link
-    await fs.symlink("/nonexistent/path/file.txt", path.join(assetDir, "broken-link.txt"));
+        // Create referenced Docker asset
+        await createTestFile(`asset.${referencedHash}/Dockerfile`, "FROM node:24");
 
-    // Verify the symlink is indeed broken
-    await expect(fs.access(path.join(assetDir, "broken-link.txt"))).rejects.toThrow();
+        // Create unreferenced Docker asset
+        const unusedHash = "9ae778431447a6965dbd163b99646b5275c91c065727748fa16e8ccc29e9dd42";
+        await createTestFile(`asset.${unusedHash}/Dockerfile`, "FROM node:24");
 
-    // Should not throw ENOENT error when calculateSize scans the directory
-    await expect(
-      cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 }),
-    ).resolves.not.toThrow();
+        // Mock collectDockerImageAssetPaths to identify Docker assets
+        const mockedCollectDockerImageAssetPaths = vi.mocked(
+          dockerCleanup.collectDockerImageAssetPaths,
+        );
+        mockedCollectDockerImageAssetPaths.mockResolvedValue(
+          new Set([
+            path.join(TEST_DIR, `asset.${referencedHash}`),
+            path.join(TEST_DIR, `asset.${unusedHash}`),
+          ]),
+        );
 
-    // Unreferenced asset with broken symlink should be deleted
-    expect(await fileExists("asset.with-broken-symlink")).toBe(false);
+        const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
+        mockedDeleteDockerImages.mockResolvedValue(0);
+
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+        // Referenced Docker asset should be protected
+        expect(await fileExists(`asset.${referencedHash}`)).toBe(true);
+
+        // Unreferenced Docker asset should be deleted
+        expect(await fileExists(`asset.${unusedHash}`)).toBe(false);
+
+        // deleteDockerImages should be called with unreferenced hash
+        expect(mockedDeleteDockerImages).toHaveBeenCalledTimes(1);
+        expect(mockedDeleteDockerImages).toHaveBeenCalledWith([unusedHash], false, undefined);
+      });
+
+      it("should show Docker images in dry-run mode", async () => {
+        await createTestManifest();
+
+        const dockerHash = "f575bdffb1fb794e3010c609b768095d4f1d64e2dca5ce27938971210488a04d";
+
+        // Create unreferenced Docker asset
+        await createTestFile(`asset.${dockerHash}/Dockerfile`, "FROM node:24");
+
+        // Mock collectDockerImageAssetPaths to identify Docker assets
+        const mockedCollectDockerImageAssetPaths = vi.mocked(
+          dockerCleanup.collectDockerImageAssetPaths,
+        );
+        mockedCollectDockerImageAssetPaths.mockResolvedValue(
+          new Set([path.join(TEST_DIR, `asset.${dockerHash}`)]),
+        );
+
+        const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
+        mockedDeleteDockerImages.mockResolvedValue(0);
+
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0 });
+
+        // Docker asset directory should NOT be deleted in dry-run mode
+        expect(await fileExists(`asset.${dockerHash}`)).toBe(true);
+
+        // deleteDockerImages should be called with dryRun=true
+        expect(mockedDeleteDockerImages).toHaveBeenCalledWith([dockerHash], true, undefined);
+      });
+
+      it("should not call deleteDockerImages for non-Docker assets", async () => {
+        await createTestManifest();
+
+        // Create unreferenced file asset (not Docker)
+        await createTestFile("asset.abc123/data.txt", "not docker");
+
+        // Mock collectDockerImageAssetPaths to return empty (no Docker assets)
+        const mockedCollectDockerImageAssetPaths = vi.mocked(
+          dockerCleanup.collectDockerImageAssetPaths,
+        );
+        mockedCollectDockerImageAssetPaths.mockResolvedValue(new Set());
+
+        const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
+
+        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+        // File asset should be deleted
+        expect(await fileExists("asset.abc123")).toBe(false);
+
+        // deleteDockerImages should not be called when there are no Docker assets
+        expect(mockedDeleteDockerImages).not.toHaveBeenCalled();
+      });
+    });
+
+    it("should only scan assembly-* directories to avoid infinite loops", async () => {
+      await createTestManifest();
+
+      // Create nested assembly-* directories (Stage nesting)
+      await createTestFile("assembly-Stage1/assembly-Stage2/cdk.out", "");
+      const nestedAssetsJson = {
+        version: "1.0.0",
+        files: {
+          nested: {
+            source: {
+              path: "../../asset.nested123",
+              packaging: "zip",
+            },
+            destinations: {},
+          },
+        },
+      };
+      await createTestFile(
+        "assembly-Stage1/assembly-Stage2/Stack.assets.json",
+        JSON.stringify(nestedAssetsJson, null, 2),
+      );
+
+      // Create asset referenced by nested assembly
+      await createTestFile("asset.nested123/index.js", "console.log('nested')");
+
+      // Create unreferenced asset
+      await createTestFile("asset.unused/old.txt", "delete me");
+
+      // Create a non-assembly directory with assets.json that should be ignored (not scanned recursively)
+      const nonAssemblyAssetsJson = {
+        version: "1.0.0",
+        files: {
+          shouldBeIgnored: {
+            source: {
+              path: "../asset.shouldBeIgnored",
+              packaging: "zip",
+            },
+            destinations: {},
+          },
+        },
+      };
+      await createTestFile(
+        "non-assembly-dir/Stack.assets.json",
+        JSON.stringify(nonAssemblyAssetsJson, null, 2),
+      );
+      await createTestFile("asset.shouldBeIgnored/data.txt", "this should be deleted");
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+      // Asset referenced in nested assembly should be protected
+      expect(await fileExists("asset.nested123/index.js")).toBe(true);
+
+      // Unreferenced asset should be deleted
+      expect(await fileExists("asset.unused")).toBe(false);
+
+      // Asset referenced in non-assembly directory should be deleted (because non-assembly dirs are not scanned)
+      expect(await fileExists("asset.shouldBeIgnored")).toBe(false);
+
+      // Non-assembly directory itself should remain (only asset.* items are deletion candidates)
+      expect(await fileExists("non-assembly-dir/Stack.assets.json")).toBe(true);
+    });
+
+    it("should handle broken symbolic links gracefully", async () => {
+      await createTestManifest();
+
+      // Create an asset directory with a broken symlink
+      const assetDir = path.join(TEST_DIR, "asset.with-broken-symlink");
+      await fs.mkdir(assetDir, { recursive: true });
+      await fs.writeFile(path.join(assetDir, "normal-file.txt"), "normal content");
+
+      // Create broken symbolic link
+      await fs.symlink("/nonexistent/path/file.txt", path.join(assetDir, "broken-link.txt"));
+
+      // Verify the symlink is indeed broken
+      await expect(fs.access(path.join(assetDir, "broken-link.txt"))).rejects.toThrow();
+
+      // Should not throw ENOENT error when calculateSize scans the directory
+      await expect(
+        cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 }),
+      ).resolves.not.toThrow();
+
+      // Unreferenced asset with broken symlink should be deleted
+      expect(await fileExists("asset.with-broken-symlink")).toBe(false);
+    });
   });
 
   it("should correctly filter protected and unprotected assets", async () => {

--- a/src/asset-cleanup.test.ts
+++ b/src/asset-cleanup.test.ts
@@ -522,7 +522,7 @@ describe("cleanupAssets", () => {
 
     // deleteDockerImages should be called with unreferenced hash
     expect(mockedDeleteDockerImages).toHaveBeenCalledTimes(1);
-    expect(mockedDeleteDockerImages).toHaveBeenCalledWith([unusedHash], false);
+    expect(mockedDeleteDockerImages).toHaveBeenCalledWith([unusedHash], false, undefined);
   });
 
   it("should show Docker images in dry-run mode", async () => {
@@ -550,7 +550,7 @@ describe("cleanupAssets", () => {
     expect(await fileExists(`asset.${dockerHash}`)).toBe(true);
 
     // deleteDockerImages should be called with dryRun=true
-    expect(mockedDeleteDockerImages).toHaveBeenCalledWith([dockerHash], true);
+    expect(mockedDeleteDockerImages).toHaveBeenCalledWith([dockerHash], true, undefined);
   });
 
   it("should not call deleteDockerImages for non-Docker assets", async () => {
@@ -659,5 +659,61 @@ describe("cleanupAssets", () => {
 
     // Unreferenced asset with broken symlink should be deleted
     expect(await fileExists("asset.with-broken-symlink")).toBe(false);
+  });
+
+  it("should show verbose output when verbose flag is enabled", async () => {
+    await createTestManifest();
+
+    // Create some test assets
+    await createTestFile("asset.unused1/file.txt", "test content");
+    await createTestFile("asset.unused2/file.txt", "test content");
+    await createTestFile("asset.used/file.txt", "test content");
+
+    // Create assets.json that references asset.used
+    const assetsJson = {
+      version: "1.0",
+      files: {
+        file1: {
+          source: { path: "asset.used" },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+    // Capture console output
+    const consoleLogSpy = vi.spyOn(console, "log");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0, verbose: true });
+
+    // Verify verbose messages are logged
+    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(logOutput).toContain("Collecting referenced assets from *.assets.json files...");
+    expect(logOutput).toContain("Found 1 referenced asset(s)");
+    expect(logOutput).toContain("Found 3 total asset(s) in directory");
+    expect(logOutput).toContain("Analyzing assets for deletion candidates...");
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should not show verbose output when verbose flag is disabled", async () => {
+    await createTestManifest();
+
+    // Create some test assets
+    await createTestFile("asset.unused1/file.txt", "test content");
+
+    // Capture console output
+    const consoleLogSpy = vi.spyOn(console, "log");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0, verbose: false });
+
+    // Verify verbose messages are not logged
+    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(logOutput).not.toContain("Collecting referenced assets from *.assets.json files...");
+    expect(logOutput).not.toContain("Analyzing assets for deletion candidates...");
+
+    consoleLogSpy.mockRestore();
   });
 });

--- a/src/asset-cleanup.test.ts
+++ b/src/asset-cleanup.test.ts
@@ -661,221 +661,223 @@ describe("cleanupAssets", () => {
     expect(await fileExists("asset.with-broken-symlink")).toBe(false);
   });
 
-  it("should show verbose output when verbose flag is enabled", async () => {
-    await createTestManifest();
+  describe("verbose mode and functional logic", () => {
+    it("should show verbose output when verbose flag is enabled", async () => {
+      await createTestManifest();
 
-    // Create some test assets
-    await createTestFile("asset.unused1/file.txt", "test content");
-    await createTestFile("asset.unused2/file.txt", "test content");
-    await createTestFile("asset.used/file.txt", "test content");
+      // Create some test assets
+      await createTestFile("asset.unused1/file.txt", "test content");
+      await createTestFile("asset.unused2/file.txt", "test content");
+      await createTestFile("asset.used/file.txt", "test content");
 
-    // Create assets.json that references asset.used
-    const assetsJson = {
-      version: "1.0",
-      files: {
-        file1: {
-          source: { path: "asset.used" },
-          destinations: {},
+      // Create assets.json that references asset.used
+      const assetsJson = {
+        version: "1.0",
+        files: {
+          file1: {
+            source: { path: "asset.used" },
+            destinations: {},
+          },
         },
-      },
-    };
-    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+      };
+      await createTestFile("test.assets.json", JSON.stringify(assetsJson));
 
-    // Capture console output
-    const consoleLogSpy = vi.spyOn(console, "log");
+      // Capture console output
+      const consoleLogSpy = vi.spyOn(console, "log");
 
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0, verbose: true });
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0, verbose: true });
 
-    // Verify verbose messages are logged
-    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      // Verify verbose messages are logged
+      const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
 
-    expect(logOutput).toContain("Collecting referenced assets from *.assets.json files...");
-    expect(logOutput).toContain("Found 1 asset(s) referenced in *.assets.json files");
-    expect(logOutput).toContain(
-      'Found 3 total asset file(s)/directory(ies) (starting with "asset.")',
-    );
-    expect(logOutput).toContain("Analyzing assets for deletion candidates...");
+      expect(logOutput).toContain("Collecting referenced assets from *.assets.json files...");
+      expect(logOutput).toContain("Found 1 asset(s) referenced in *.assets.json files");
+      expect(logOutput).toContain(
+        'Found 3 total asset file(s)/directory(ies) (starting with "asset.")',
+      );
+      expect(logOutput).toContain("Analyzing assets for deletion candidates...");
 
-    consoleLogSpy.mockRestore();
-  });
+      consoleLogSpy.mockRestore();
+    });
 
-  it("should not show verbose output when verbose flag is disabled", async () => {
-    await createTestManifest();
+    it("should not show verbose output when verbose flag is disabled", async () => {
+      await createTestManifest();
 
-    // Create some test assets
-    await createTestFile("asset.unused1/file.txt", "test content");
+      // Create some test assets
+      await createTestFile("asset.unused1/file.txt", "test content");
 
-    // Capture console output
-    const consoleLogSpy = vi.spyOn(console, "log");
+      // Capture console output
+      const consoleLogSpy = vi.spyOn(console, "log");
 
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0, verbose: false });
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0, verbose: false });
 
-    // Verify verbose messages are not logged
-    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      // Verify verbose messages are not logged
+      const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
 
-    expect(logOutput).not.toContain("Collecting referenced assets from *.assets.json files...");
-    expect(logOutput).not.toContain("Analyzing assets for deletion candidates...");
+      expect(logOutput).not.toContain("Collecting referenced assets from *.assets.json files...");
+      expect(logOutput).not.toContain("Analyzing assets for deletion candidates...");
 
-    consoleLogSpy.mockRestore();
-  });
+      consoleLogSpy.mockRestore();
+    });
 
-  it("should correctly filter protected and unprotected assets", async () => {
-    await createTestManifest();
+    it("should correctly filter protected and unprotected assets", async () => {
+      await createTestManifest();
 
-    // Create referenced asset (should be protected)
-    await createTestFile("asset.referenced/file.txt", "referenced");
+      // Create referenced asset (should be protected)
+      await createTestFile("asset.referenced/file.txt", "referenced");
 
-    // Create old unreferenced asset (should be deleted with keep-hours=0)
-    await createTestFile("asset.old/file.txt", "old");
+      // Create old unreferenced asset (should be deleted with keep-hours=0)
+      await createTestFile("asset.old/file.txt", "old");
 
-    // Reference one asset
-    const assetsJson = {
-      version: "1.0",
-      files: {
-        file1: {
-          source: { path: "asset.referenced" },
-          destinations: {},
+      // Reference one asset
+      const assetsJson = {
+        version: "1.0",
+        files: {
+          file1: {
+            source: { path: "asset.referenced" },
+            destinations: {},
+          },
         },
-      },
-    };
-    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+      };
+      await createTestFile("test.assets.json", JSON.stringify(assetsJson));
 
-    // Run cleanup with keep-hours=0 (only referenced assets protected)
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+      // Run cleanup with keep-hours=0 (only referenced assets protected)
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
 
-    // Verify: referenced should exist, old should be deleted
-    expect(await fileExists("asset.referenced")).toBe(true);
-    expect(await fileExists("asset.old")).toBe(false);
-  });
+      // Verify: referenced should exist, old should be deleted
+      expect(await fileExists("asset.referenced")).toBe(true);
+      expect(await fileExists("asset.old")).toBe(false);
+    });
 
-  it("should handle multiple protection reasons correctly", async () => {
-    await createTestManifest();
+    it("should handle multiple protection reasons correctly", async () => {
+      await createTestManifest();
 
-    // Create asset that is both referenced AND recent
-    await createTestFile("asset.both/file.txt", "both protected");
+      // Create asset that is both referenced AND recent
+      await createTestFile("asset.both/file.txt", "both protected");
 
-    // Create asset that is only referenced
-    await createTestFile("asset.onlyref/file.txt", "only referenced");
+      // Create asset that is only referenced
+      await createTestFile("asset.onlyref/file.txt", "only referenced");
 
-    // Reference both assets
-    const assetsJson = {
-      version: "1.0",
-      files: {
-        file1: {
-          source: { path: "asset.both" },
-          destinations: {},
+      // Reference both assets
+      const assetsJson = {
+        version: "1.0",
+        files: {
+          file1: {
+            source: { path: "asset.both" },
+            destinations: {},
+          },
+          file2: {
+            source: { path: "asset.onlyref" },
+            destinations: {},
+          },
         },
-        file2: {
-          source: { path: "asset.onlyref" },
-          destinations: {},
+      };
+      await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+      // Run with verbose to check protection reason
+      const consoleLogSpy = vi.spyOn(console, "log");
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 24, verbose: true });
+
+      const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+      // Both should show "referenced in *.assets.json" as the reason
+      // (referenced takes precedence over recent in our implementation)
+      expect(logOutput).toContain("asset.both");
+      expect(logOutput).toContain("asset.onlyref");
+      expect(logOutput).toContain("referenced in *.assets.json");
+
+      // Both assets should still exist
+      expect(await fileExists("asset.both")).toBe(true);
+      expect(await fileExists("asset.onlyref")).toBe(true);
+
+      consoleLogSpy.mockRestore();
+    });
+
+    it("should correctly map filtered results to deletion candidates", async () => {
+      await createTestManifest();
+
+      // Create mix of assets
+      await createTestFile("asset.delete1/file.txt", "delete1");
+      await createTestFile("asset.delete2/file.txt", "delete2");
+      await createTestFile("asset.delete3/file.txt", "delete3");
+      await createTestFile("asset.protected/file.txt", "protected");
+
+      // Reference only one
+      const assetsJson = {
+        version: "1.0",
+        files: {
+          file1: {
+            source: { path: "asset.protected" },
+            destinations: {},
+          },
         },
-      },
-    };
-    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+      };
+      await createTestFile("test.assets.json", JSON.stringify(assetsJson));
 
-    // Run with verbose to check protection reason
-    const consoleLogSpy = vi.spyOn(console, "log");
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
 
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 24, verbose: true });
+      // Verify the filter/map worked correctly: 3 deleted, 1 protected
+      expect(await fileExists("asset.delete1")).toBe(false);
+      expect(await fileExists("asset.delete2")).toBe(false);
+      expect(await fileExists("asset.delete3")).toBe(false);
+      expect(await fileExists("asset.protected")).toBe(true);
+    });
 
-    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    it("should handle empty asset list correctly", async () => {
+      await createTestManifest();
 
-    // Both should show "referenced in *.assets.json" as the reason
-    // (referenced takes precedence over recent in our implementation)
-    expect(logOutput).toContain("asset.both");
-    expect(logOutput).toContain("asset.onlyref");
-    expect(logOutput).toContain("referenced in *.assets.json");
+      // No assets at all, just manifest
+      const consoleLogSpy = vi.spyOn(console, "log");
 
-    // Both assets should still exist
-    expect(await fileExists("asset.both")).toBe(true);
-    expect(await fileExists("asset.onlyref")).toBe(true);
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
 
-    consoleLogSpy.mockRestore();
-  });
+      const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
 
-  it("should correctly map filtered results to deletion candidates", async () => {
-    await createTestManifest();
+      // Should show 0 assets found
+      expect(logOutput).toContain("Found 0 total asset file(s)/directory(ies)");
+      expect(logOutput).toContain("No unused assets found");
 
-    // Create mix of assets
-    await createTestFile("asset.delete1/file.txt", "delete1");
-    await createTestFile("asset.delete2/file.txt", "delete2");
-    await createTestFile("asset.delete3/file.txt", "delete3");
-    await createTestFile("asset.protected/file.txt", "protected");
+      consoleLogSpy.mockRestore();
+    });
 
-    // Reference only one
-    const assetsJson = {
-      version: "1.0",
-      files: {
-        file1: {
-          source: { path: "asset.protected" },
-          destinations: {},
+    it("should handle all assets being protected", async () => {
+      await createTestManifest();
+
+      // Create only referenced assets
+      await createTestFile("asset.ref1/file.txt", "ref1");
+      await createTestFile("asset.ref2/file.txt", "ref2");
+
+      const assetsJson = {
+        version: "1.0",
+        files: {
+          file1: {
+            source: { path: "asset.ref1" },
+            destinations: {},
+          },
+          file2: {
+            source: { path: "asset.ref2" },
+            destinations: {},
+          },
         },
-      },
-    };
-    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+      };
+      await createTestFile("test.assets.json", JSON.stringify(assetsJson));
 
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+      const consoleLogSpy = vi.spyOn(console, "log");
 
-    // Verify the filter/map worked correctly: 3 deleted, 1 protected
-    expect(await fileExists("asset.delete1")).toBe(false);
-    expect(await fileExists("asset.delete2")).toBe(false);
-    expect(await fileExists("asset.delete3")).toBe(false);
-    expect(await fileExists("asset.protected")).toBe(true);
-  });
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
 
-  it("should handle empty asset list correctly", async () => {
-    await createTestManifest();
+      const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
 
-    // No assets at all, just manifest
-    const consoleLogSpy = vi.spyOn(console, "log");
+      // Should show all protected, no unused assets
+      expect(logOutput).toContain("Protected assets:");
+      expect(logOutput).toContain("No unused assets found");
 
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
+      // All should still exist
+      expect(await fileExists("asset.ref1")).toBe(true);
+      expect(await fileExists("asset.ref2")).toBe(true);
 
-    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
-
-    // Should show 0 assets found
-    expect(logOutput).toContain("Found 0 total asset file(s)/directory(ies)");
-    expect(logOutput).toContain("No unused assets found");
-
-    consoleLogSpy.mockRestore();
-  });
-
-  it("should handle all assets being protected", async () => {
-    await createTestManifest();
-
-    // Create only referenced assets
-    await createTestFile("asset.ref1/file.txt", "ref1");
-    await createTestFile("asset.ref2/file.txt", "ref2");
-
-    const assetsJson = {
-      version: "1.0",
-      files: {
-        file1: {
-          source: { path: "asset.ref1" },
-          destinations: {},
-        },
-        file2: {
-          source: { path: "asset.ref2" },
-          destinations: {},
-        },
-      },
-    };
-    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
-
-    const consoleLogSpy = vi.spyOn(console, "log");
-
-    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
-
-    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
-
-    // Should show all protected, no unused assets
-    expect(logOutput).toContain("Protected assets:");
-    expect(logOutput).toContain("No unused assets found");
-
-    // All should still exist
-    expect(await fileExists("asset.ref1")).toBe(true);
-    expect(await fileExists("asset.ref2")).toBe(true);
-
-    consoleLogSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+    });
   });
 });

--- a/src/asset-cleanup.test.ts
+++ b/src/asset-cleanup.test.ts
@@ -193,480 +193,480 @@ describe("cleanupAssets", () => {
       expect(await fileExists("asset.referenced-file.txt")).toBe(true);
       expect(await fileExists("asset.unreferenced-file.txt")).toBe(false);
     });
+  });
 
-    describe("edge cases", () => {
-      it("should throw error if directory does not exist", async () => {
-        await expect(
-          cleanupAssets({ outdir: "/non-existent-dir", dryRun: false, keepHours: 0 }),
-        ).rejects.toThrow("Directory not found");
-      });
-
-      it("should handle empty directory gracefully", async () => {
-        await createTestManifest();
-
-        await expect(
-          cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 }),
-        ).resolves.not.toThrow();
-      });
-
-      it("should protect assets used by multiple stacks", async () => {
-        await createTestManifest();
-
-        // Create two stacks that share the same asset
-        const stack1AssetsJson = {
-          version: "1.0.0",
-          files: {
-            shared123: {
-              source: {
-                path: "asset.shared123",
-                packaging: "zip",
-              },
-              destinations: {},
-            },
-            stack1only: {
-              source: {
-                path: "asset.stack1only",
-                packaging: "file",
-              },
-              destinations: {},
-            },
-          },
-        };
-
-        const stack2AssetsJson = {
-          version: "1.0.0",
-          files: {
-            shared123: {
-              source: {
-                path: "asset.shared123",
-                packaging: "zip",
-              },
-              destinations: {},
-            },
-            stack2only: {
-              source: {
-                path: "asset.stack2only",
-                packaging: "file",
-              },
-              destinations: {},
-            },
-          },
-        };
-
-        await createTestFile("Stack1.assets.json", JSON.stringify(stack1AssetsJson, null, 2));
-        await createTestFile("Stack2.assets.json", JSON.stringify(stack2AssetsJson, null, 2));
-
-        // Create asset directories
-        await createTestFile("asset.shared123/index.js", "console.log('shared')");
-        await createTestFile("asset.stack1only/data1.json", '{"stack":1}');
-        await createTestFile("asset.stack2only/data2.json", '{"stack":2}');
-        await createTestFile("asset.unused/old.txt", "delete me");
-
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-        // Shared asset should be protected
-        expect(await fileExists("asset.shared123/index.js")).toBe(true);
-
-        // Stack-specific assets should be protected
-        expect(await fileExists("asset.stack1only/data1.json")).toBe(true);
-        expect(await fileExists("asset.stack2only/data2.json")).toBe(true);
-
-        // Unreferenced asset should be deleted
-        expect(await fileExists("asset.unused")).toBe(false);
-      });
-
-      it("should protect unreferenced assets with --keep-hours", async () => {
-        await createTestManifest();
-
-        // Create an assets.json file with one reference
-        const assetsJson = {
-          version: "1.0.0",
-          files: {
-            referenced: {
-              source: {
-                path: "asset.referenced",
-                packaging: "zip",
-              },
-              destinations: {},
-            },
-          },
-        };
-
-        await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
-
-        // Create referenced and unreferenced assets
-        await createTestFile("asset.referenced/index.js", "console.log('referenced')");
-        await createTestFile("asset.recent-unreferenced/index.js", "console.log('recent')");
-
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 1 });
-
-        // Referenced asset should be protected
-        expect(await fileExists("asset.referenced/index.js")).toBe(true);
-
-        // Recent unreferenced asset should be protected by keepHours
-        expect(await fileExists("asset.recent-unreferenced/index.js")).toBe(true);
-      });
-
-      it("should not delete user files (non-asset files)", async () => {
-        await createTestManifest();
-
-        // Create an assets.json file
-        const assetsJson = {
-          version: "1.0.0",
-          files: {
-            referenced: {
-              source: {
-                path: "asset.referenced",
-                packaging: "zip",
-              },
-              destinations: {},
-            },
-          },
-        };
-
-        await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
-
-        // Create CDK-generated asset
-        await createTestFile("asset.referenced/index.js", "console.log('referenced')");
-
-        // Create user files that should NOT be deleted
-        await createTestFile("my-notes.txt", "User notes");
-        await createTestFile("debug.log", "Debug log");
-        await createTestFile("temp-data/data.json", '{"test":true}');
-
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-        // Referenced asset should be protected
-        expect(await fileExists("asset.referenced/index.js")).toBe(true);
-
-        // User files should NOT be deleted
-        expect(await fileExists("my-notes.txt")).toBe(true);
-        expect(await fileExists("debug.log")).toBe(true);
-        expect(await fileExists("temp-data/data.json")).toBe(true);
-      });
-
-      it("should handle negative keepHours (treat as 0)", async () => {
-        await createTestManifest();
-        await createTestFile("asset.old/file.txt", "old file");
-
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: -1 });
-
-        // Negative value should be treated as no time-based protection
-        expect(await fileExists("asset.old")).toBe(false);
-      });
-
-      it("should handle very large keepHours value", async () => {
-        await createTestManifest();
-        await createTestFile("asset.recent/file.txt", "recent file");
-
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 99999 });
-
-        // Very large value should protect all recent files
-        expect(await fileExists("asset.recent/file.txt")).toBe(true);
-      });
-
-      it("should handle fractional keepHours value", async () => {
-        await createTestManifest();
-        await createTestFile("asset.verynew/file.txt", "very new file");
-
-        // 0.001 hours = 3.6 seconds
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0.001 });
-
-        // File created just now should be protected
-        expect(await fileExists("asset.verynew/file.txt")).toBe(true);
-      });
-
-      it("should delete assets older than keepHours and protect newer ones", async () => {
-        await createTestManifest();
-
-        // Create assets with different ages
-        const oldAssetPath = path.join(TEST_DIR, "asset.old");
-        const newAssetPath = path.join(TEST_DIR, "asset.new");
-        const boundaryAssetPath = path.join(TEST_DIR, "asset.boundary");
-
-        await fs.mkdir(oldAssetPath, { recursive: true });
-        await fs.writeFile(path.join(oldAssetPath, "file.txt"), "old content");
-
-        await fs.mkdir(newAssetPath, { recursive: true });
-        await fs.writeFile(path.join(newAssetPath, "file.txt"), "new content");
-
-        await fs.mkdir(boundaryAssetPath, { recursive: true });
-        await fs.writeFile(path.join(boundaryAssetPath, "file.txt"), "boundary content");
-
-        // Set modification times relative to when cleanup will run
-        // Add buffer to account for test execution time
-        const now = Date.now();
-        const fourHoursAgo = now - 4 * 60 * 60 * 1000; // 4 hours ago
-        const twoHoursAgo = now - 2 * 60 * 60 * 1000; // 2 hours ago
-        const threeHoursAgo = now - 3 * 60 * 60 * 1000 + 100; // Just under 3 hours ago
-
-        await fs.utimes(oldAssetPath, new Date(fourHoursAgo), new Date(fourHoursAgo));
-        await fs.utimes(newAssetPath, new Date(twoHoursAgo), new Date(twoHoursAgo));
-        await fs.utimes(boundaryAssetPath, new Date(threeHoursAgo), new Date(threeHoursAgo));
-
-        // Clean with keepHours: 3
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 3 });
-
-        // Asset older than 3 hours should be deleted
-        expect(await fileExists("asset.old")).toBe(false);
-
-        // Asset newer than 3 hours should be protected
-        expect(await fileExists("asset.new")).toBe(true);
-
-        // Asset exactly at 3 hours boundary should be protected (<=)
-        expect(await fileExists("asset.boundary")).toBe(true);
-      });
+  describe("edge cases", () => {
+    it("should throw error if directory does not exist", async () => {
+      await expect(
+        cleanupAssets({ outdir: "/non-existent-dir", dryRun: false, keepHours: 0 }),
+      ).rejects.toThrow("Directory not found");
     });
 
-    it("should protect assets referenced in nested assembly directories", async () => {
+    it("should handle empty directory gracefully", async () => {
       await createTestManifest();
 
-      // Create nested assembly directory structure
-      await createTestFile("assembly-MyStage/cdk.out", "");
-      await createTestFile("assembly-MyStage/manifest.json", "{}");
-      await createTestFile("assembly-MyStage/MyStageCdkSampleStackC627666C.template.json", "{}");
-
-      // Create assets.json in nested assembly that references top-level asset with relative path
-      const nestedAssetsJson = {
-        version: "1.0.0",
-        files: {
-          asset1: {
-            source: {
-              path: "../asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098",
-              packaging: "zip",
-            },
-            destinations: {},
-          },
-        },
-      };
-      await createTestFile(
-        "assembly-MyStage/MyStageCdkSampleStackC627666C.assets.json",
-        JSON.stringify(nestedAssetsJson, null, 2),
-      );
-
-      // Create assets at top level
-      await createTestFile(
-        "asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098/index.js",
-        "console.log('stage asset')",
-      );
-      await createTestFile("asset.unused/old.txt", "delete me");
-
-      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-      // Asset referenced in nested assembly should be protected
-      expect(await fileExists("assembly-MyStage/cdk.out")).toBe(true);
-      expect(await fileExists("assembly-MyStage/manifest.json")).toBe(true);
-      expect(await fileExists("assembly-MyStage/MyStageCdkSampleStackC627666C.template.json")).toBe(
-        true,
-      );
-      expect(await fileExists("assembly-MyStage/MyStageCdkSampleStackC627666C.assets.json")).toBe(
-        true,
-      );
-      expect(
-        await fileExists(
-          "asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098/index.js",
-        ),
-      ).toBe(true);
-
-      // Unreferenced asset should be deleted
-      expect(await fileExists("asset.unused")).toBe(false);
-    });
-
-    describe("Docker image cleanup", () => {
-      it("should delete Docker images when deleting Docker asset directories", async () => {
-        await createTestManifest();
-
-        const referencedHash = "f575bdffb1fb794e3010c609b768095d4f1d64e2dca5ce27938971210488a04d";
-        const assetsJson = {
-          version: "1.0.0",
-          dockerImages: {
-            [referencedHash]: {
-              source: {
-                directory: `asset.${referencedHash}`,
-              },
-              destinations: {
-                "123456789012-us-east-1-xxx": {
-                  repositoryName: "cdk-hnb659fds-container-assets-123456789012-us-east-1",
-                  imageTag: referencedHash,
-                  region: "us-east-1",
-                },
-              },
-            },
-          },
-        };
-
-        await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
-
-        // Create referenced Docker asset
-        await createTestFile(`asset.${referencedHash}/Dockerfile`, "FROM node:24");
-
-        // Create unreferenced Docker asset
-        const unusedHash = "9ae778431447a6965dbd163b99646b5275c91c065727748fa16e8ccc29e9dd42";
-        await createTestFile(`asset.${unusedHash}/Dockerfile`, "FROM node:24");
-
-        // Mock collectDockerImageAssetPaths to identify Docker assets
-        const mockedCollectDockerImageAssetPaths = vi.mocked(
-          dockerCleanup.collectDockerImageAssetPaths,
-        );
-        mockedCollectDockerImageAssetPaths.mockResolvedValue(
-          new Set([
-            path.join(TEST_DIR, `asset.${referencedHash}`),
-            path.join(TEST_DIR, `asset.${unusedHash}`),
-          ]),
-        );
-
-        const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
-        mockedDeleteDockerImages.mockResolvedValue(0);
-
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-        // Referenced Docker asset should be protected
-        expect(await fileExists(`asset.${referencedHash}`)).toBe(true);
-
-        // Unreferenced Docker asset should be deleted
-        expect(await fileExists(`asset.${unusedHash}`)).toBe(false);
-
-        // deleteDockerImages should be called with unreferenced hash
-        expect(mockedDeleteDockerImages).toHaveBeenCalledTimes(1);
-        expect(mockedDeleteDockerImages).toHaveBeenCalledWith([unusedHash], false, undefined);
-      });
-
-      it("should show Docker images in dry-run mode", async () => {
-        await createTestManifest();
-
-        const dockerHash = "f575bdffb1fb794e3010c609b768095d4f1d64e2dca5ce27938971210488a04d";
-
-        // Create unreferenced Docker asset
-        await createTestFile(`asset.${dockerHash}/Dockerfile`, "FROM node:24");
-
-        // Mock collectDockerImageAssetPaths to identify Docker assets
-        const mockedCollectDockerImageAssetPaths = vi.mocked(
-          dockerCleanup.collectDockerImageAssetPaths,
-        );
-        mockedCollectDockerImageAssetPaths.mockResolvedValue(
-          new Set([path.join(TEST_DIR, `asset.${dockerHash}`)]),
-        );
-
-        const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
-        mockedDeleteDockerImages.mockResolvedValue(0);
-
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0 });
-
-        // Docker asset directory should NOT be deleted in dry-run mode
-        expect(await fileExists(`asset.${dockerHash}`)).toBe(true);
-
-        // deleteDockerImages should be called with dryRun=true
-        expect(mockedDeleteDockerImages).toHaveBeenCalledWith([dockerHash], true, undefined);
-      });
-
-      it("should not call deleteDockerImages for non-Docker assets", async () => {
-        await createTestManifest();
-
-        // Create unreferenced file asset (not Docker)
-        await createTestFile("asset.abc123/data.txt", "not docker");
-
-        // Mock collectDockerImageAssetPaths to return empty (no Docker assets)
-        const mockedCollectDockerImageAssetPaths = vi.mocked(
-          dockerCleanup.collectDockerImageAssetPaths,
-        );
-        mockedCollectDockerImageAssetPaths.mockResolvedValue(new Set());
-
-        const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
-
-        await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-        // File asset should be deleted
-        expect(await fileExists("asset.abc123")).toBe(false);
-
-        // deleteDockerImages should not be called when there are no Docker assets
-        expect(mockedDeleteDockerImages).not.toHaveBeenCalled();
-      });
-    });
-
-    it("should only scan assembly-* directories to avoid infinite loops", async () => {
-      await createTestManifest();
-
-      // Create nested assembly-* directories (Stage nesting)
-      await createTestFile("assembly-Stage1/assembly-Stage2/cdk.out", "");
-      const nestedAssetsJson = {
-        version: "1.0.0",
-        files: {
-          nested: {
-            source: {
-              path: "../../asset.nested123",
-              packaging: "zip",
-            },
-            destinations: {},
-          },
-        },
-      };
-      await createTestFile(
-        "assembly-Stage1/assembly-Stage2/Stack.assets.json",
-        JSON.stringify(nestedAssetsJson, null, 2),
-      );
-
-      // Create asset referenced by nested assembly
-      await createTestFile("asset.nested123/index.js", "console.log('nested')");
-
-      // Create unreferenced asset
-      await createTestFile("asset.unused/old.txt", "delete me");
-
-      // Create a non-assembly directory with assets.json that should be ignored (not scanned recursively)
-      const nonAssemblyAssetsJson = {
-        version: "1.0.0",
-        files: {
-          shouldBeIgnored: {
-            source: {
-              path: "../asset.shouldBeIgnored",
-              packaging: "zip",
-            },
-            destinations: {},
-          },
-        },
-      };
-      await createTestFile(
-        "non-assembly-dir/Stack.assets.json",
-        JSON.stringify(nonAssemblyAssetsJson, null, 2),
-      );
-      await createTestFile("asset.shouldBeIgnored/data.txt", "this should be deleted");
-
-      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-      // Asset referenced in nested assembly should be protected
-      expect(await fileExists("asset.nested123/index.js")).toBe(true);
-
-      // Unreferenced asset should be deleted
-      expect(await fileExists("asset.unused")).toBe(false);
-
-      // Asset referenced in non-assembly directory should be deleted (because non-assembly dirs are not scanned)
-      expect(await fileExists("asset.shouldBeIgnored")).toBe(false);
-
-      // Non-assembly directory itself should remain (only asset.* items are deletion candidates)
-      expect(await fileExists("non-assembly-dir/Stack.assets.json")).toBe(true);
-    });
-
-    it("should handle broken symbolic links gracefully", async () => {
-      await createTestManifest();
-
-      // Create an asset directory with a broken symlink
-      const assetDir = path.join(TEST_DIR, "asset.with-broken-symlink");
-      await fs.mkdir(assetDir, { recursive: true });
-      await fs.writeFile(path.join(assetDir, "normal-file.txt"), "normal content");
-
-      // Create broken symbolic link
-      await fs.symlink("/nonexistent/path/file.txt", path.join(assetDir, "broken-link.txt"));
-
-      // Verify the symlink is indeed broken
-      await expect(fs.access(path.join(assetDir, "broken-link.txt"))).rejects.toThrow();
-
-      // Should not throw ENOENT error when calculateSize scans the directory
       await expect(
         cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 }),
       ).resolves.not.toThrow();
-
-      // Unreferenced asset with broken symlink should be deleted
-      expect(await fileExists("asset.with-broken-symlink")).toBe(false);
     });
+
+    it("should protect assets used by multiple stacks", async () => {
+      await createTestManifest();
+
+      // Create two stacks that share the same asset
+      const stack1AssetsJson = {
+        version: "1.0.0",
+        files: {
+          shared123: {
+            source: {
+              path: "asset.shared123",
+              packaging: "zip",
+            },
+            destinations: {},
+          },
+          stack1only: {
+            source: {
+              path: "asset.stack1only",
+              packaging: "file",
+            },
+            destinations: {},
+          },
+        },
+      };
+
+      const stack2AssetsJson = {
+        version: "1.0.0",
+        files: {
+          shared123: {
+            source: {
+              path: "asset.shared123",
+              packaging: "zip",
+            },
+            destinations: {},
+          },
+          stack2only: {
+            source: {
+              path: "asset.stack2only",
+              packaging: "file",
+            },
+            destinations: {},
+          },
+        },
+      };
+
+      await createTestFile("Stack1.assets.json", JSON.stringify(stack1AssetsJson, null, 2));
+      await createTestFile("Stack2.assets.json", JSON.stringify(stack2AssetsJson, null, 2));
+
+      // Create asset directories
+      await createTestFile("asset.shared123/index.js", "console.log('shared')");
+      await createTestFile("asset.stack1only/data1.json", '{"stack":1}');
+      await createTestFile("asset.stack2only/data2.json", '{"stack":2}');
+      await createTestFile("asset.unused/old.txt", "delete me");
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+      // Shared asset should be protected
+      expect(await fileExists("asset.shared123/index.js")).toBe(true);
+
+      // Stack-specific assets should be protected
+      expect(await fileExists("asset.stack1only/data1.json")).toBe(true);
+      expect(await fileExists("asset.stack2only/data2.json")).toBe(true);
+
+      // Unreferenced asset should be deleted
+      expect(await fileExists("asset.unused")).toBe(false);
+    });
+
+    it("should protect unreferenced assets with --keep-hours", async () => {
+      await createTestManifest();
+
+      // Create an assets.json file with one reference
+      const assetsJson = {
+        version: "1.0.0",
+        files: {
+          referenced: {
+            source: {
+              path: "asset.referenced",
+              packaging: "zip",
+            },
+            destinations: {},
+          },
+        },
+      };
+
+      await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
+
+      // Create referenced and unreferenced assets
+      await createTestFile("asset.referenced/index.js", "console.log('referenced')");
+      await createTestFile("asset.recent-unreferenced/index.js", "console.log('recent')");
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 1 });
+
+      // Referenced asset should be protected
+      expect(await fileExists("asset.referenced/index.js")).toBe(true);
+
+      // Recent unreferenced asset should be protected by keepHours
+      expect(await fileExists("asset.recent-unreferenced/index.js")).toBe(true);
+    });
+
+    it("should not delete user files (non-asset files)", async () => {
+      await createTestManifest();
+
+      // Create an assets.json file
+      const assetsJson = {
+        version: "1.0.0",
+        files: {
+          referenced: {
+            source: {
+              path: "asset.referenced",
+              packaging: "zip",
+            },
+            destinations: {},
+          },
+        },
+      };
+
+      await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
+
+      // Create CDK-generated asset
+      await createTestFile("asset.referenced/index.js", "console.log('referenced')");
+
+      // Create user files that should NOT be deleted
+      await createTestFile("my-notes.txt", "User notes");
+      await createTestFile("debug.log", "Debug log");
+      await createTestFile("temp-data/data.json", '{"test":true}');
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+      // Referenced asset should be protected
+      expect(await fileExists("asset.referenced/index.js")).toBe(true);
+
+      // User files should NOT be deleted
+      expect(await fileExists("my-notes.txt")).toBe(true);
+      expect(await fileExists("debug.log")).toBe(true);
+      expect(await fileExists("temp-data/data.json")).toBe(true);
+    });
+
+    it("should handle negative keepHours (treat as 0)", async () => {
+      await createTestManifest();
+      await createTestFile("asset.old/file.txt", "old file");
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: -1 });
+
+      // Negative value should be treated as no time-based protection
+      expect(await fileExists("asset.old")).toBe(false);
+    });
+
+    it("should handle very large keepHours value", async () => {
+      await createTestManifest();
+      await createTestFile("asset.recent/file.txt", "recent file");
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 99999 });
+
+      // Very large value should protect all recent files
+      expect(await fileExists("asset.recent/file.txt")).toBe(true);
+    });
+
+    it("should handle fractional keepHours value", async () => {
+      await createTestManifest();
+      await createTestFile("asset.verynew/file.txt", "very new file");
+
+      // 0.001 hours = 3.6 seconds
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0.001 });
+
+      // File created just now should be protected
+      expect(await fileExists("asset.verynew/file.txt")).toBe(true);
+    });
+
+    it("should delete assets older than keepHours and protect newer ones", async () => {
+      await createTestManifest();
+
+      // Create assets with different ages
+      const oldAssetPath = path.join(TEST_DIR, "asset.old");
+      const newAssetPath = path.join(TEST_DIR, "asset.new");
+      const boundaryAssetPath = path.join(TEST_DIR, "asset.boundary");
+
+      await fs.mkdir(oldAssetPath, { recursive: true });
+      await fs.writeFile(path.join(oldAssetPath, "file.txt"), "old content");
+
+      await fs.mkdir(newAssetPath, { recursive: true });
+      await fs.writeFile(path.join(newAssetPath, "file.txt"), "new content");
+
+      await fs.mkdir(boundaryAssetPath, { recursive: true });
+      await fs.writeFile(path.join(boundaryAssetPath, "file.txt"), "boundary content");
+
+      // Set modification times relative to when cleanup will run
+      // Add buffer to account for test execution time
+      const now = Date.now();
+      const fourHoursAgo = now - 4 * 60 * 60 * 1000; // 4 hours ago
+      const twoHoursAgo = now - 2 * 60 * 60 * 1000; // 2 hours ago
+      const threeHoursAgo = now - 3 * 60 * 60 * 1000 + 100; // Just under 3 hours ago
+
+      await fs.utimes(oldAssetPath, new Date(fourHoursAgo), new Date(fourHoursAgo));
+      await fs.utimes(newAssetPath, new Date(twoHoursAgo), new Date(twoHoursAgo));
+      await fs.utimes(boundaryAssetPath, new Date(threeHoursAgo), new Date(threeHoursAgo));
+
+      // Clean with keepHours: 3
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 3 });
+
+      // Asset older than 3 hours should be deleted
+      expect(await fileExists("asset.old")).toBe(false);
+
+      // Asset newer than 3 hours should be protected
+      expect(await fileExists("asset.new")).toBe(true);
+
+      // Asset exactly at 3 hours boundary should be protected (<=)
+      expect(await fileExists("asset.boundary")).toBe(true);
+    });
+  });
+
+  it("should protect assets referenced in nested assembly directories", async () => {
+    await createTestManifest();
+
+    // Create nested assembly directory structure
+    await createTestFile("assembly-MyStage/cdk.out", "");
+    await createTestFile("assembly-MyStage/manifest.json", "{}");
+    await createTestFile("assembly-MyStage/MyStageCdkSampleStackC627666C.template.json", "{}");
+
+    // Create assets.json in nested assembly that references top-level asset with relative path
+    const nestedAssetsJson = {
+      version: "1.0.0",
+      files: {
+        asset1: {
+          source: {
+            path: "../asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098",
+            packaging: "zip",
+          },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile(
+      "assembly-MyStage/MyStageCdkSampleStackC627666C.assets.json",
+      JSON.stringify(nestedAssetsJson, null, 2),
+    );
+
+    // Create assets at top level
+    await createTestFile(
+      "asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098/index.js",
+      "console.log('stage asset')",
+    );
+    await createTestFile("asset.unused/old.txt", "delete me");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+    // Asset referenced in nested assembly should be protected
+    expect(await fileExists("assembly-MyStage/cdk.out")).toBe(true);
+    expect(await fileExists("assembly-MyStage/manifest.json")).toBe(true);
+    expect(await fileExists("assembly-MyStage/MyStageCdkSampleStackC627666C.template.json")).toBe(
+      true,
+    );
+    expect(await fileExists("assembly-MyStage/MyStageCdkSampleStackC627666C.assets.json")).toBe(
+      true,
+    );
+    expect(
+      await fileExists(
+        "asset.1b74676f43a7db3c2b7b40ca7b8ae1cffa9314da05f888ba85f0e5bdbba35098/index.js",
+      ),
+    ).toBe(true);
+
+    // Unreferenced asset should be deleted
+    expect(await fileExists("asset.unused")).toBe(false);
+  });
+
+  describe("Docker image cleanup", () => {
+    it("should delete Docker images when deleting Docker asset directories", async () => {
+      await createTestManifest();
+
+      const referencedHash = "f575bdffb1fb794e3010c609b768095d4f1d64e2dca5ce27938971210488a04d";
+      const assetsJson = {
+        version: "1.0.0",
+        dockerImages: {
+          [referencedHash]: {
+            source: {
+              directory: `asset.${referencedHash}`,
+            },
+            destinations: {
+              "123456789012-us-east-1-xxx": {
+                repositoryName: "cdk-hnb659fds-container-assets-123456789012-us-east-1",
+                imageTag: referencedHash,
+                region: "us-east-1",
+              },
+            },
+          },
+        },
+      };
+
+      await createTestFile("Stack.assets.json", JSON.stringify(assetsJson, null, 2));
+
+      // Create referenced Docker asset
+      await createTestFile(`asset.${referencedHash}/Dockerfile`, "FROM node:24");
+
+      // Create unreferenced Docker asset
+      const unusedHash = "9ae778431447a6965dbd163b99646b5275c91c065727748fa16e8ccc29e9dd42";
+      await createTestFile(`asset.${unusedHash}/Dockerfile`, "FROM node:24");
+
+      // Mock collectDockerImageAssetPaths to identify Docker assets
+      const mockedCollectDockerImageAssetPaths = vi.mocked(
+        dockerCleanup.collectDockerImageAssetPaths,
+      );
+      mockedCollectDockerImageAssetPaths.mockResolvedValue(
+        new Set([
+          path.join(TEST_DIR, `asset.${referencedHash}`),
+          path.join(TEST_DIR, `asset.${unusedHash}`),
+        ]),
+      );
+
+      const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
+      mockedDeleteDockerImages.mockResolvedValue(0);
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+      // Referenced Docker asset should be protected
+      expect(await fileExists(`asset.${referencedHash}`)).toBe(true);
+
+      // Unreferenced Docker asset should be deleted
+      expect(await fileExists(`asset.${unusedHash}`)).toBe(false);
+
+      // deleteDockerImages should be called with unreferenced hash
+      expect(mockedDeleteDockerImages).toHaveBeenCalledTimes(1);
+      expect(mockedDeleteDockerImages).toHaveBeenCalledWith([unusedHash], false, undefined);
+    });
+
+    it("should show Docker images in dry-run mode", async () => {
+      await createTestManifest();
+
+      const dockerHash = "f575bdffb1fb794e3010c609b768095d4f1d64e2dca5ce27938971210488a04d";
+
+      // Create unreferenced Docker asset
+      await createTestFile(`asset.${dockerHash}/Dockerfile`, "FROM node:24");
+
+      // Mock collectDockerImageAssetPaths to identify Docker assets
+      const mockedCollectDockerImageAssetPaths = vi.mocked(
+        dockerCleanup.collectDockerImageAssetPaths,
+      );
+      mockedCollectDockerImageAssetPaths.mockResolvedValue(
+        new Set([path.join(TEST_DIR, `asset.${dockerHash}`)]),
+      );
+
+      const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
+      mockedDeleteDockerImages.mockResolvedValue(0);
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 0 });
+
+      // Docker asset directory should NOT be deleted in dry-run mode
+      expect(await fileExists(`asset.${dockerHash}`)).toBe(true);
+
+      // deleteDockerImages should be called with dryRun=true
+      expect(mockedDeleteDockerImages).toHaveBeenCalledWith([dockerHash], true, undefined);
+    });
+
+    it("should not call deleteDockerImages for non-Docker assets", async () => {
+      await createTestManifest();
+
+      // Create unreferenced file asset (not Docker)
+      await createTestFile("asset.abc123/data.txt", "not docker");
+
+      // Mock collectDockerImageAssetPaths to return empty (no Docker assets)
+      const mockedCollectDockerImageAssetPaths = vi.mocked(
+        dockerCleanup.collectDockerImageAssetPaths,
+      );
+      mockedCollectDockerImageAssetPaths.mockResolvedValue(new Set());
+
+      const mockedDeleteDockerImages = vi.mocked(dockerCleanup.deleteDockerImages);
+
+      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+      // File asset should be deleted
+      expect(await fileExists("asset.abc123")).toBe(false);
+
+      // deleteDockerImages should not be called when there are no Docker assets
+      expect(mockedDeleteDockerImages).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should only scan assembly-* directories to avoid infinite loops", async () => {
+    await createTestManifest();
+
+    // Create nested assembly-* directories (Stage nesting)
+    await createTestFile("assembly-Stage1/assembly-Stage2/cdk.out", "");
+    const nestedAssetsJson = {
+      version: "1.0.0",
+      files: {
+        nested: {
+          source: {
+            path: "../../asset.nested123",
+            packaging: "zip",
+          },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile(
+      "assembly-Stage1/assembly-Stage2/Stack.assets.json",
+      JSON.stringify(nestedAssetsJson, null, 2),
+    );
+
+    // Create asset referenced by nested assembly
+    await createTestFile("asset.nested123/index.js", "console.log('nested')");
+
+    // Create unreferenced asset
+    await createTestFile("asset.unused/old.txt", "delete me");
+
+    // Create a non-assembly directory with assets.json that should be ignored (not scanned recursively)
+    const nonAssemblyAssetsJson = {
+      version: "1.0.0",
+      files: {
+        shouldBeIgnored: {
+          source: {
+            path: "../asset.shouldBeIgnored",
+            packaging: "zip",
+          },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile(
+      "non-assembly-dir/Stack.assets.json",
+      JSON.stringify(nonAssemblyAssetsJson, null, 2),
+    );
+    await createTestFile("asset.shouldBeIgnored/data.txt", "this should be deleted");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+    // Asset referenced in nested assembly should be protected
+    expect(await fileExists("asset.nested123/index.js")).toBe(true);
+
+    // Unreferenced asset should be deleted
+    expect(await fileExists("asset.unused")).toBe(false);
+
+    // Asset referenced in non-assembly directory should be deleted (because non-assembly dirs are not scanned)
+    expect(await fileExists("asset.shouldBeIgnored")).toBe(false);
+
+    // Non-assembly directory itself should remain (only asset.* items are deletion candidates)
+    expect(await fileExists("non-assembly-dir/Stack.assets.json")).toBe(true);
+  });
+
+  it("should handle broken symbolic links gracefully", async () => {
+    await createTestManifest();
+
+    // Create an asset directory with a broken symlink
+    const assetDir = path.join(TEST_DIR, "asset.with-broken-symlink");
+    await fs.mkdir(assetDir, { recursive: true });
+    await fs.writeFile(path.join(assetDir, "normal-file.txt"), "normal content");
+
+    // Create broken symbolic link
+    await fs.symlink("/nonexistent/path/file.txt", path.join(assetDir, "broken-link.txt"));
+
+    // Verify the symlink is indeed broken
+    await expect(fs.access(path.join(assetDir, "broken-link.txt"))).rejects.toThrow();
+
+    // Should not throw ENOENT error when calculateSize scans the directory
+    await expect(
+      cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 }),
+    ).resolves.not.toThrow();
+
+    // Unreferenced asset with broken symlink should be deleted
+    expect(await fileExists("asset.with-broken-symlink")).toBe(false);
   });
 
   it("should correctly filter protected and unprotected assets", async () => {

--- a/src/asset-cleanup.test.ts
+++ b/src/asset-cleanup.test.ts
@@ -661,7 +661,167 @@ describe("cleanupAssets", () => {
     expect(await fileExists("asset.with-broken-symlink")).toBe(false);
   });
 
-  describe("verbose mode and functional logic", () => {
+  it("should correctly filter protected and unprotected assets", async () => {
+    await createTestManifest();
+
+    // Create referenced asset (should be protected)
+    await createTestFile("asset.referenced/file.txt", "referenced");
+
+    // Create old unreferenced asset (should be deleted with keep-hours=0)
+    await createTestFile("asset.old/file.txt", "old");
+
+    // Reference one asset
+    const assetsJson = {
+      version: "1.0",
+      files: {
+        file1: {
+          source: { path: "asset.referenced" },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+    // Run cleanup with keep-hours=0 (only referenced assets protected)
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+    // Verify: referenced should exist, old should be deleted
+    expect(await fileExists("asset.referenced")).toBe(true);
+    expect(await fileExists("asset.old")).toBe(false);
+  });
+
+  it("should handle multiple protection reasons correctly", async () => {
+    await createTestManifest();
+
+    // Create asset that is both referenced AND recent
+    await createTestFile("asset.both/file.txt", "both protected");
+
+    // Create asset that is only referenced
+    await createTestFile("asset.onlyref/file.txt", "only referenced");
+
+    // Reference both assets
+    const assetsJson = {
+      version: "1.0",
+      files: {
+        file1: {
+          source: { path: "asset.both" },
+          destinations: {},
+        },
+        file2: {
+          source: { path: "asset.onlyref" },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+    // Run with verbose to check protection reason
+    const consoleLogSpy = vi.spyOn(console, "log");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 24, verbose: true });
+
+    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    // Both should show "referenced in *.assets.json" as the reason
+    // (referenced takes precedence over recent in our implementation)
+    expect(logOutput).toContain("asset.both");
+    expect(logOutput).toContain("asset.onlyref");
+    expect(logOutput).toContain("referenced in *.assets.json");
+
+    // Both assets should still exist
+    expect(await fileExists("asset.both")).toBe(true);
+    expect(await fileExists("asset.onlyref")).toBe(true);
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should correctly map filtered results to deletion candidates", async () => {
+    await createTestManifest();
+
+    // Create mix of assets
+    await createTestFile("asset.delete1/file.txt", "delete1");
+    await createTestFile("asset.delete2/file.txt", "delete2");
+    await createTestFile("asset.delete3/file.txt", "delete3");
+    await createTestFile("asset.protected/file.txt", "protected");
+
+    // Reference only one
+    const assetsJson = {
+      version: "1.0",
+      files: {
+        file1: {
+          source: { path: "asset.protected" },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
+
+    // Verify the filter/map worked correctly: 3 deleted, 1 protected
+    expect(await fileExists("asset.delete1")).toBe(false);
+    expect(await fileExists("asset.delete2")).toBe(false);
+    expect(await fileExists("asset.delete3")).toBe(false);
+    expect(await fileExists("asset.protected")).toBe(true);
+  });
+
+  it("should handle empty asset list correctly", async () => {
+    await createTestManifest();
+
+    // No assets at all, just manifest
+    const consoleLogSpy = vi.spyOn(console, "log");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
+
+    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    // Should show 0 assets found
+    expect(logOutput).toContain("Found 0 total asset file(s)/directory(ies)");
+    expect(logOutput).toContain("No unused assets found");
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should handle all assets being protected", async () => {
+    await createTestManifest();
+
+    // Create only referenced assets
+    await createTestFile("asset.ref1/file.txt", "ref1");
+    await createTestFile("asset.ref2/file.txt", "ref2");
+
+    const assetsJson = {
+      version: "1.0",
+      files: {
+        file1: {
+          source: { path: "asset.ref1" },
+          destinations: {},
+        },
+        file2: {
+          source: { path: "asset.ref2" },
+          destinations: {},
+        },
+      },
+    };
+    await createTestFile("test.assets.json", JSON.stringify(assetsJson));
+
+    const consoleLogSpy = vi.spyOn(console, "log");
+
+    await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
+
+    const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    // Should show all protected, no unused assets
+    expect(logOutput).toContain("Protected assets:");
+    expect(logOutput).toContain("No unused assets found");
+
+    // All should still exist
+    expect(await fileExists("asset.ref1")).toBe(true);
+    expect(await fileExists("asset.ref2")).toBe(true);
+
+    consoleLogSpy.mockRestore();
+  });
+
+  describe("verbose mode", () => {
     it("should show verbose output when verbose flag is enabled", async () => {
       await createTestManifest();
 
@@ -716,166 +876,6 @@ describe("cleanupAssets", () => {
 
       expect(logOutput).not.toContain("Collecting referenced assets from *.assets.json files...");
       expect(logOutput).not.toContain("Analyzing assets for deletion candidates...");
-
-      consoleLogSpy.mockRestore();
-    });
-
-    it("should correctly filter protected and unprotected assets", async () => {
-      await createTestManifest();
-
-      // Create referenced asset (should be protected)
-      await createTestFile("asset.referenced/file.txt", "referenced");
-
-      // Create old unreferenced asset (should be deleted with keep-hours=0)
-      await createTestFile("asset.old/file.txt", "old");
-
-      // Reference one asset
-      const assetsJson = {
-        version: "1.0",
-        files: {
-          file1: {
-            source: { path: "asset.referenced" },
-            destinations: {},
-          },
-        },
-      };
-      await createTestFile("test.assets.json", JSON.stringify(assetsJson));
-
-      // Run cleanup with keep-hours=0 (only referenced assets protected)
-      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-      // Verify: referenced should exist, old should be deleted
-      expect(await fileExists("asset.referenced")).toBe(true);
-      expect(await fileExists("asset.old")).toBe(false);
-    });
-
-    it("should handle multiple protection reasons correctly", async () => {
-      await createTestManifest();
-
-      // Create asset that is both referenced AND recent
-      await createTestFile("asset.both/file.txt", "both protected");
-
-      // Create asset that is only referenced
-      await createTestFile("asset.onlyref/file.txt", "only referenced");
-
-      // Reference both assets
-      const assetsJson = {
-        version: "1.0",
-        files: {
-          file1: {
-            source: { path: "asset.both" },
-            destinations: {},
-          },
-          file2: {
-            source: { path: "asset.onlyref" },
-            destinations: {},
-          },
-        },
-      };
-      await createTestFile("test.assets.json", JSON.stringify(assetsJson));
-
-      // Run with verbose to check protection reason
-      const consoleLogSpy = vi.spyOn(console, "log");
-
-      await cleanupAssets({ outdir: TEST_DIR, dryRun: true, keepHours: 24, verbose: true });
-
-      const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
-
-      // Both should show "referenced in *.assets.json" as the reason
-      // (referenced takes precedence over recent in our implementation)
-      expect(logOutput).toContain("asset.both");
-      expect(logOutput).toContain("asset.onlyref");
-      expect(logOutput).toContain("referenced in *.assets.json");
-
-      // Both assets should still exist
-      expect(await fileExists("asset.both")).toBe(true);
-      expect(await fileExists("asset.onlyref")).toBe(true);
-
-      consoleLogSpy.mockRestore();
-    });
-
-    it("should correctly map filtered results to deletion candidates", async () => {
-      await createTestManifest();
-
-      // Create mix of assets
-      await createTestFile("asset.delete1/file.txt", "delete1");
-      await createTestFile("asset.delete2/file.txt", "delete2");
-      await createTestFile("asset.delete3/file.txt", "delete3");
-      await createTestFile("asset.protected/file.txt", "protected");
-
-      // Reference only one
-      const assetsJson = {
-        version: "1.0",
-        files: {
-          file1: {
-            source: { path: "asset.protected" },
-            destinations: {},
-          },
-        },
-      };
-      await createTestFile("test.assets.json", JSON.stringify(assetsJson));
-
-      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0 });
-
-      // Verify the filter/map worked correctly: 3 deleted, 1 protected
-      expect(await fileExists("asset.delete1")).toBe(false);
-      expect(await fileExists("asset.delete2")).toBe(false);
-      expect(await fileExists("asset.delete3")).toBe(false);
-      expect(await fileExists("asset.protected")).toBe(true);
-    });
-
-    it("should handle empty asset list correctly", async () => {
-      await createTestManifest();
-
-      // No assets at all, just manifest
-      const consoleLogSpy = vi.spyOn(console, "log");
-
-      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
-
-      const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
-
-      // Should show 0 assets found
-      expect(logOutput).toContain("Found 0 total asset file(s)/directory(ies)");
-      expect(logOutput).toContain("No unused assets found");
-
-      consoleLogSpy.mockRestore();
-    });
-
-    it("should handle all assets being protected", async () => {
-      await createTestManifest();
-
-      // Create only referenced assets
-      await createTestFile("asset.ref1/file.txt", "ref1");
-      await createTestFile("asset.ref2/file.txt", "ref2");
-
-      const assetsJson = {
-        version: "1.0",
-        files: {
-          file1: {
-            source: { path: "asset.ref1" },
-            destinations: {},
-          },
-          file2: {
-            source: { path: "asset.ref2" },
-            destinations: {},
-          },
-        },
-      };
-      await createTestFile("test.assets.json", JSON.stringify(assetsJson));
-
-      const consoleLogSpy = vi.spyOn(console, "log");
-
-      await cleanupAssets({ outdir: TEST_DIR, dryRun: false, keepHours: 0, verbose: true });
-
-      const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
-
-      // Should show all protected, no unused assets
-      expect(logOutput).toContain("Protected assets:");
-      expect(logOutput).toContain("No unused assets found");
-
-      // All should still exist
-      expect(await fileExists("asset.ref1")).toBe(true);
-      expect(await fileExists("asset.ref2")).toBe(true);
 
       consoleLogSpy.mockRestore();
     });

--- a/src/asset-cleanup.test.ts
+++ b/src/asset-cleanup.test.ts
@@ -690,8 +690,8 @@ describe("cleanupAssets", () => {
     const logOutput = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
 
     expect(logOutput).toContain("Collecting referenced assets from *.assets.json files...");
-    expect(logOutput).toContain("Found 1 referenced asset(s)");
-    expect(logOutput).toContain("Found 3 total asset(s) in directory");
+    expect(logOutput).toContain("Found 1 asset(s) referenced in *.assets.json files");
+    expect(logOutput).toContain('Found 3 total asset file(s)/directory(ies) (starting with "asset.")');
     expect(logOutput).toContain("Analyzing assets for deletion candidates...");
 
     consoleLogSpy.mockRestore();

--- a/src/asset-cleanup.ts
+++ b/src/asset-cleanup.ts
@@ -234,10 +234,7 @@ function displayProtectedItems(
 /**
  * Display items to be deleted
  */
-function displayItemsToDelete(
-  items: Array<{ path: string; size: number }>,
-  outdir: string,
-): void {
+function displayItemsToDelete(items: Array<{ path: string; size: number }>, outdir: string): void {
   for (const item of items) {
     const relativePath = path.relative(outdir, item.path);
     console.log(`  - ${relativePath} (${formatSize(item.size)})`);

--- a/src/asset-cleanup.ts
+++ b/src/asset-cleanup.ts
@@ -11,13 +11,14 @@ export interface CleanupOptions {
   outdir: string;
   dryRun: boolean;
   keepHours: number;
+  verbose?: boolean;
 }
 
 /**
  * Clean up cdk.out directory
  */
 export async function cleanupAssets(options: CleanupOptions): Promise<void> {
-  const { outdir, dryRun, keepHours } = options;
+  const { outdir, dryRun, keepHours, verbose } = options;
 
   const fullPath = path.resolve(outdir);
   console.log(`Scanning ${fullPath}`);
@@ -30,22 +31,44 @@ export async function cleanupAssets(options: CleanupOptions): Promise<void> {
     throw new Error(`Directory not found: ${fullPath}`);
   }
 
+  if (verbose) {
+    console.log("Collecting referenced assets from *.assets.json files...");
+  }
+
   // Collect asset paths referenced in *.assets.json files
   const activePaths = await collectAssetPaths(outdir);
+
+  if (verbose) {
+    console.log(`Found ${activePaths.size} referenced asset(s)\n`);
+  }
 
   // Scan directory items
   const entries = await fs.readdir(outdir);
   const assetEntries = entries.filter((entry) => entry.startsWith("asset."));
 
+  if (verbose) {
+    console.log(`Found ${assetEntries.length} total asset(s) in directory`);
+  }
+
   // Collect all Docker image asset paths (both active and to-be-deleted)
   const allDockerImageAssetPaths = await collectDockerImageAssetPaths(assetEntries, outdir);
 
+  if (verbose) {
+    console.log("Analyzing assets for deletion candidates...\n");
+  }
+
+  const protectedItems: Array<{ path: string; reason: string; size: number }> = [];
   const itemsToDelete = (
     await Promise.all(
       assetEntries.map(async (entry) => {
         const itemPath = path.join(outdir, entry);
 
-        if (await isProtected(itemPath, activePaths, keepHours)) {
+        const protectionReason = await getProtectionReason(itemPath, activePaths, keepHours);
+        if (protectionReason) {
+          if (verbose) {
+            const size = await calculateSize(itemPath);
+            protectedItems.push({ path: itemPath, reason: protectionReason, size });
+          }
           return null;
         }
 
@@ -57,6 +80,15 @@ export async function cleanupAssets(options: CleanupOptions): Promise<void> {
   ).filter(
     (item): item is { path: string; size: number; isDockerImageAsset: boolean } => item !== null,
   );
+
+  if (verbose && protectedItems.length > 0) {
+    console.log("Protected assets:");
+    for (const item of protectedItems) {
+      const relativePath = path.relative(outdir, item.path);
+      console.log(`  ⊘ ${relativePath} (${formatSize(item.size)}) - ${item.reason}`);
+    }
+    console.log("");
+  }
 
   // Display results
   if (itemsToDelete.length === 0) {
@@ -80,14 +112,26 @@ export async function cleanupAssets(options: CleanupOptions): Promise<void> {
   console.log(`\nTotal assets size to reclaim: ${formatSize(totalSize)}\n`);
 
   if (!dryRun) {
+    if (verbose) {
+      console.log("Deleting assets:");
+    }
     await Promise.all(
-      itemsToDelete.map((item) => fs.rm(item.path, { recursive: true, force: true })),
+      itemsToDelete.map(async (item) => {
+        if (verbose) {
+          const relativePath = path.relative(outdir, item.path);
+          console.log(`  → Deleting ${relativePath}...`);
+        }
+        await fs.rm(item.path, { recursive: true, force: true });
+      }),
     );
+    if (verbose) {
+      console.log("");
+    }
   }
 
   let dockerImageSize = 0;
   if (dockerImageHashes.length > 0) {
-    dockerImageSize = await deleteDockerImages(dockerImageHashes, dryRun);
+    dockerImageSize = await deleteDockerImages(dockerImageHashes, dryRun, verbose);
   }
 
   console.log("");
@@ -160,16 +204,17 @@ async function collectAssetPaths(dirPath: string): Promise<Set<string>> {
 }
 
 /**
- * Check if file/directory should be protected from deletion
+ * Get the reason why a file/directory should be protected from deletion
+ * Returns null if not protected
  */
-async function isProtected(
+async function getProtectionReason(
   itemPath: string,
   activePaths: Set<string>,
   keepHours: number,
-): Promise<boolean> {
+): Promise<string | null> {
   // Protect assets referenced in *.assets.json files
   if (activePaths.has(itemPath)) {
-    return true;
+    return "referenced in *.assets.json";
   }
 
   // Protect files/directories within retention period
@@ -177,9 +222,9 @@ async function isProtected(
     const stats = await fs.stat(itemPath);
     const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
     if (ageHours <= keepHours) {
-      return true;
+      return `modified within last ${keepHours} hour(s)`;
     }
   }
 
-  return false;
+  return null;
 }

--- a/src/asset-cleanup.ts
+++ b/src/asset-cleanup.ts
@@ -52,7 +52,9 @@ export async function cleanupAssets(options: CleanupOptions): Promise<void> {
   const assetEntries = entries.filter((entry) => entry.startsWith("asset."));
 
   if (verbose) {
-    console.log(`Found ${assetEntries.length} total asset file(s)/directory(ies) (starting with "asset.")`);
+    console.log(
+      `Found ${assetEntries.length} total asset file(s)/directory(ies) (starting with "asset.")`,
+    );
   }
 
   // Collect all Docker image asset paths (both active and to-be-deleted)

--- a/src/asset-cleanup.ts
+++ b/src/asset-cleanup.ts
@@ -47,7 +47,7 @@ export async function cleanupAssets(options: CleanupOptions): Promise<void> {
   const assetEntries = entries.filter((entry) => entry.startsWith("asset."));
 
   if (verbose) {
-    console.log(`Found ${assetEntries.length} total asset(s) in directory`);
+    console.log(`Found ${assetEntries.length} total asset file(s)/directory(ies) (starting with "asset.")`);
   }
 
   // Collect all Docker image asset paths (both active and to-be-deleted)

--- a/src/asset-cleanup.ts
+++ b/src/asset-cleanup.ts
@@ -14,6 +14,11 @@ export interface CleanupOptions {
   verbose?: boolean;
 }
 
+interface ProtectionResult {
+  isProtected: boolean;
+  reason?: string;
+}
+
 /**
  * Clean up cdk.out directory
  */
@@ -57,35 +62,32 @@ export async function cleanupAssets(options: CleanupOptions): Promise<void> {
     console.log("Analyzing assets for deletion candidates...\n");
   }
 
-  const protectedItems: Array<{ path: string; reason: string; size: number }> = [];
-  const itemsToDelete = (
-    await Promise.all(
-      assetEntries.map(async (entry) => {
-        const itemPath = path.join(outdir, entry);
+  const analysisResults = await Promise.all(
+    assetEntries.map(async (entry) => {
+      const itemPath = path.join(outdir, entry);
+      const protection = await checkProtection(itemPath, activePaths, keepHours);
+      const size = await calculateSize(itemPath);
+      const isDockerImageAsset = allDockerImageAssetPaths.has(itemPath);
 
-        const protectionReason = await getProtectionReason(itemPath, activePaths, keepHours);
-        if (protectionReason) {
-          if (verbose) {
-            const size = await calculateSize(itemPath);
-            protectedItems.push({ path: itemPath, reason: protectionReason, size });
-          }
-          return null;
-        }
-
-        const size = await calculateSize(itemPath);
-        const isDockerImageAsset = allDockerImageAssetPaths.has(itemPath);
-        return { path: itemPath, size, isDockerImageAsset };
-      }),
-    )
-  ).filter(
-    (item): item is { path: string; size: number; isDockerImageAsset: boolean } => item !== null,
+      return {
+        path: itemPath,
+        size,
+        isDockerImageAsset,
+        protection,
+      };
+    }),
   );
+
+  const protectedItems = analysisResults.filter((item) => item.protection.isProtected);
+  const itemsToDelete = analysisResults
+    .filter((item) => !item.protection.isProtected)
+    .map(({ path, size, isDockerImageAsset }) => ({ path, size, isDockerImageAsset }));
 
   if (verbose && protectedItems.length > 0) {
     console.log("Protected assets:");
     for (const item of protectedItems) {
       const relativePath = path.relative(outdir, item.path);
-      console.log(`  ⊘ ${relativePath} (${formatSize(item.size)}) - ${item.reason}`);
+      console.log(`  ⊘ ${relativePath} (${formatSize(item.size)}) - ${item.protection.reason}`);
     }
     console.log("");
   }
@@ -204,17 +206,16 @@ async function collectAssetPaths(dirPath: string): Promise<Set<string>> {
 }
 
 /**
- * Get the reason why a file/directory should be protected from deletion
- * Returns null if not protected
+ * Check if a file/directory should be protected from deletion
  */
-async function getProtectionReason(
+async function checkProtection(
   itemPath: string,
   activePaths: Set<string>,
   keepHours: number,
-): Promise<string | null> {
+): Promise<ProtectionResult> {
   // Protect assets referenced in *.assets.json files
   if (activePaths.has(itemPath)) {
-    return "referenced in *.assets.json";
+    return { isProtected: true, reason: "referenced in *.assets.json" };
   }
 
   // Protect files/directories within retention period
@@ -222,9 +223,9 @@ async function getProtectionReason(
     const stats = await fs.stat(itemPath);
     const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
     if (ageHours <= keepHours) {
-      return `modified within last ${keepHours} hour(s)`;
+      return { isProtected: true, reason: `modified within last ${keepHours} hour(s)` };
     }
   }
 
-  return null;
+  return { isProtected: false };
 }

--- a/src/asset-cleanup.ts
+++ b/src/asset-cleanup.ts
@@ -85,52 +85,32 @@ export async function cleanupAssets(options: CleanupOptions): Promise<void> {
     .filter((item) => !item.protection.isProtected)
     .map(({ path, size, isDockerImageAsset }) => ({ path, size, isDockerImageAsset }));
 
-  if (verbose && protectedItems.length > 0) {
-    console.log("Protected assets:");
-    for (const item of protectedItems) {
-      const relativePath = path.relative(outdir, item.path);
-      console.log(`  ⊘ ${relativePath} (${formatSize(item.size)}) - ${item.protection.reason}`);
-    }
-    console.log("");
+  // Display protected items if verbose
+  if (verbose) {
+    displayProtectedItems(protectedItems, outdir);
   }
 
-  // Display results
+  // Early return if nothing to delete
   if (itemsToDelete.length === 0) {
     console.log(`✓ No unused assets found.`);
     return;
   }
 
+  // Display items to delete and collect Docker image hashes
   console.log(`Found ${itemsToDelete.length} unused item(s):`);
+  displayItemsToDelete(itemsToDelete, outdir);
 
-  // Display items and collect Docker image hashes (from Docker image assets only)
   const dockerImageHashes = itemsToDelete
-    .map((item) => {
-      const relativePath = path.relative(outdir, item.path);
-      console.log(`  - ${relativePath} (${formatSize(item.size)})`);
-      // Extract hash only for Docker image assets
-      return item.isDockerImageAsset ? extractDockerImageHash(item.path) : null;
-    })
+    .filter((item) => item.isDockerImageAsset)
+    .map((item) => extractDockerImageHash(item.path))
     .filter((hash): hash is string => hash !== null);
 
   const totalSize = itemsToDelete.reduce((sum, item) => sum + item.size, 0);
   console.log(`\nTotal assets size to reclaim: ${formatSize(totalSize)}\n`);
 
+  // Delete assets
   if (!dryRun) {
-    if (verbose) {
-      console.log("Deleting assets:");
-    }
-    await Promise.all(
-      itemsToDelete.map(async (item) => {
-        if (verbose) {
-          const relativePath = path.relative(outdir, item.path);
-          console.log(`  → Deleting ${relativePath}...`);
-        }
-        await fs.rm(item.path, { recursive: true, force: true });
-      }),
-    );
-    if (verbose) {
-      console.log("");
-    }
+    await deleteAssetsWithProgress(itemsToDelete, outdir, verbose ?? false);
   }
 
   let dockerImageSize = 0;
@@ -230,4 +210,63 @@ async function checkProtection(
   }
 
   return { isProtected: false };
+}
+
+/**
+ * Display protected items in verbose mode
+ */
+function displayProtectedItems(
+  items: Array<{ path: string; size: number; protection: ProtectionResult }>,
+  outdir: string,
+): void {
+  if (items.length === 0) {
+    return;
+  }
+
+  console.log("Protected assets:");
+  for (const item of items) {
+    const relativePath = path.relative(outdir, item.path);
+    console.log(`  ⊘ ${relativePath} (${formatSize(item.size)}) - ${item.protection.reason}`);
+  }
+  console.log("");
+}
+
+/**
+ * Display items to be deleted
+ */
+function displayItemsToDelete(
+  items: Array<{ path: string; size: number }>,
+  outdir: string,
+): void {
+  for (const item of items) {
+    const relativePath = path.relative(outdir, item.path);
+    console.log(`  - ${relativePath} (${formatSize(item.size)})`);
+  }
+}
+
+/**
+ * Delete assets with optional verbose progress output
+ */
+async function deleteAssetsWithProgress(
+  items: Array<{ path: string }>,
+  outdir: string,
+  verbose: boolean,
+): Promise<void> {
+  if (verbose) {
+    console.log("Deleting assets:");
+  }
+
+  await Promise.all(
+    items.map(async (item) => {
+      if (verbose) {
+        const relativePath = path.relative(outdir, item.path);
+        console.log(`  → Deleting ${relativePath}...`);
+      }
+      await fs.rm(item.path, { recursive: true, force: true });
+    }),
+  );
+
+  if (verbose) {
+    console.log("");
+  }
 }

--- a/src/asset-cleanup.ts
+++ b/src/asset-cleanup.ts
@@ -39,7 +39,7 @@ export async function cleanupAssets(options: CleanupOptions): Promise<void> {
   const activePaths = await collectAssetPaths(outdir);
 
   if (verbose) {
-    console.log(`Found ${activePaths.size} referenced asset(s)\n`);
+    console.log(`Found ${activePaths.size} asset(s) referenced in *.assets.json files\n`);
   }
 
   // Scan directory items

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ program
   .option("-d, --dry-run", "Show what would be deleted without actually deleting", false)
   .option("-k, --keep-hours <number>", "Protect files modified within this many hours", "0")
   .option("-t, --cleanup-tmp", "Clean up all temporary cdk.out directories in $TMPDIR", false)
+  .option("-v, --verbose", "Show detailed operation information", false)
   .action(async (options) => {
     try {
       const keepHours = parseInt(options.keepHours, 10);
@@ -35,12 +36,14 @@ program
         await cleanupTempDirectories({
           dryRun: options.dryRun,
           keepHours,
+          verbose: options.verbose,
         });
       } else {
         await cleanupAssets({
           outdir: options.outdir,
           dryRun: options.dryRun,
           keepHours,
+          verbose: options.verbose,
         });
       }
     } catch (error) {

--- a/src/docker-cleanup.ts
+++ b/src/docker-cleanup.ts
@@ -56,13 +56,23 @@ export function extractDockerImageHash(assetPath: string): string | null {
  * Only prints header if at least one image is found
  * Returns the total size of Docker images in bytes
  */
-export async function deleteDockerImages(hashes: string[], dryRun: boolean): Promise<number> {
+export async function deleteDockerImages(
+  hashes: string[],
+  dryRun: boolean,
+  verbose = false,
+): Promise<number> {
   if (hashes.length === 0) {
     return 0;
   }
 
   // Get all Docker images once with size information
   const dockerCommand = getDockerCommand();
+
+  if (verbose) {
+    console.log("Searching for Docker images...");
+    console.log(`Using Docker command: ${dockerCommand}\n`);
+  }
+
   let allImagesOutput: string;
   try {
     allImagesOutput = execSync(
@@ -83,14 +93,21 @@ export async function deleteDockerImages(hashes: string[], dryRun: boolean): Pro
   const existingHashes = hashes.filter((hash) => imageExistsInOutput(hash, allImagesOutput));
 
   if (existingHashes.length === 0) {
+    if (verbose) {
+      console.log("No Docker images found matching deleted assets.\n");
+    }
     return 0;
+  }
+
+  if (verbose) {
+    console.log(`Found ${existingHashes.length} Docker image(s) to remove\n`);
   }
 
   console.log("");
 
   let totalDockerSize = 0;
   for (const hash of existingHashes) {
-    const size = await deleteDockerImageFromOutput(hash, allImagesOutput, dryRun);
+    const size = await deleteDockerImageFromOutput(hash, allImagesOutput, dryRun, verbose);
     totalDockerSize += size;
   }
 
@@ -131,6 +148,7 @@ async function deleteDockerImageFromOutput(
   hash: string,
   allImagesOutput: string,
   dryRun: boolean,
+  verbose = false,
 ): Promise<number> {
   // Search all images for all tags with this hash and extract size
   const matchingLines = allImagesOutput
@@ -162,15 +180,24 @@ async function deleteDockerImageFromOutput(
   console.log("");
 
   if (!dryRun) {
+    if (verbose) {
+      console.log("  Removing Docker image(s):");
+    }
     const dockerCommand = getDockerCommand();
     for (const tag of allTags) {
       try {
+        if (verbose) {
+          console.log(`    → ${dockerCommand} image rm ${tag}`);
+        }
         execSync(`${dockerCommand} image rm ${tag}`, { stdio: "pipe" });
       } catch (error) {
         console.warn(
           `    Warning: Failed to delete Docker image ${tag}: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
+    }
+    if (verbose) {
+      console.log("");
     }
   }
 

--- a/src/temp-cleanup.test.ts
+++ b/src/temp-cleanup.test.ts
@@ -108,4 +108,127 @@ describe("cleanupTempDirectories", () => {
       os.tmpdir = originalTmpdir;
     }
   });
+
+  it("should correctly filter protected and unprotected directories", async () => {
+    const originalTmpdir = os.tmpdir;
+    os.tmpdir = () => TEST_TMPDIR;
+
+    try {
+      await createTempCdkDir("cdk-recent");
+      const oldDir = await createTempCdkDir("cdk-old");
+
+      // Set old directory to 10 hours ago
+      const tenHoursAgo = Date.now() - 10 * 60 * 60 * 1000;
+      await fs.utimes(oldDir, new Date(tenHoursAgo), new Date(tenHoursAgo));
+
+      await cleanupTempDirectories({ dryRun: false, keepHours: 5 });
+
+      // Recent directory should be protected by keepHours
+      expect(await dirExists("cdk-recent")).toBe(true);
+      // Old directory should be deleted
+      expect(await dirExists("cdk-old")).toBe(false);
+    } finally {
+      os.tmpdir = originalTmpdir;
+    }
+  });
+
+  it("should handle multiple directories with different ages", async () => {
+    const originalTmpdir = os.tmpdir;
+    os.tmpdir = () => TEST_TMPDIR;
+
+    try {
+      await createTempCdkDir("cdk-very-recent");
+      const recentDir = await createTempCdkDir("cdk-recent");
+      const oldDir = await createTempCdkDir("cdk-old");
+
+      // Set different ages
+      const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+      const sixHoursAgo = Date.now() - 6 * 60 * 60 * 1000;
+
+      await fs.utimes(recentDir, new Date(twoHoursAgo), new Date(twoHoursAgo));
+      await fs.utimes(oldDir, new Date(sixHoursAgo), new Date(sixHoursAgo));
+
+      await cleanupTempDirectories({ dryRun: false, keepHours: 4 });
+
+      // Very recent and recent directories should be protected
+      expect(await dirExists("cdk-very-recent")).toBe(true);
+      expect(await dirExists("cdk-recent")).toBe(true);
+      // Old directory should be deleted
+      expect(await dirExists("cdk-old")).toBe(false);
+    } finally {
+      os.tmpdir = originalTmpdir;
+    }
+  });
+
+  it("should correctly map filtered results to deletion candidates", async () => {
+    const originalTmpdir = os.tmpdir;
+    os.tmpdir = () => TEST_TMPDIR;
+
+    try {
+      await createTempCdkDir("cdk-dir1");
+      await createTempCdkDir("cdk-dir2");
+      await createTempCdkDir("cdk-dir3");
+      const protectedDir = await createTempCdkDir("cdk-protected");
+
+      // Set protected directory to be recent
+      const oneHourAgo = Date.now() - 1 * 60 * 60 * 1000;
+      await fs.utimes(protectedDir, new Date(oneHourAgo), new Date(oneHourAgo));
+
+      // Set other directories to be old
+      const tenHoursAgo = Date.now() - 10 * 60 * 60 * 1000;
+      for (const name of ["cdk-dir1", "cdk-dir2", "cdk-dir3"]) {
+        const dirPath = path.join(TEST_TMPDIR, name);
+        await fs.utimes(dirPath, new Date(tenHoursAgo), new Date(tenHoursAgo));
+      }
+
+      await cleanupTempDirectories({ dryRun: false, keepHours: 2 });
+
+      // Protected directory should exist
+      expect(await dirExists("cdk-protected")).toBe(true);
+      // Other directories should be deleted
+      expect(await dirExists("cdk-dir1")).toBe(false);
+      expect(await dirExists("cdk-dir2")).toBe(false);
+      expect(await dirExists("cdk-dir3")).toBe(false);
+    } finally {
+      os.tmpdir = originalTmpdir;
+    }
+  });
+
+  it("should handle empty directory list correctly", async () => {
+    const originalTmpdir = os.tmpdir;
+    os.tmpdir = () => TEST_TMPDIR;
+
+    try {
+      // No CDK directories created
+      await fs.mkdir(path.join(TEST_TMPDIR, "other-dir"), { recursive: true });
+
+      // Should not throw and complete successfully
+      await cleanupTempDirectories({ dryRun: false, keepHours: 0 });
+
+      expect(await dirExists("other-dir")).toBe(true);
+    } finally {
+      os.tmpdir = originalTmpdir;
+    }
+  });
+
+  it("should handle all directories being protected", async () => {
+    const originalTmpdir = os.tmpdir;
+    os.tmpdir = () => TEST_TMPDIR;
+
+    try {
+      await createTempCdkDir("cdk-dir1");
+      await createTempCdkDir("cdk-dir2");
+      await createTempCdkDir("cdk-dir3");
+
+      // All directories are recent (protected by keepHours)
+      await cleanupTempDirectories({ dryRun: false, keepHours: 24 });
+
+      // All directories should still exist
+      expect(await dirExists("cdk-dir1")).toBe(true);
+      expect(await dirExists("cdk-dir2")).toBe(true);
+      expect(await dirExists("cdk-dir3")).toBe(true);
+    } finally {
+      os.tmpdir = originalTmpdir;
+    }
+  });
 });

--- a/src/temp-cleanup.ts
+++ b/src/temp-cleanup.ts
@@ -6,13 +6,14 @@ import { calculateSize, formatSize } from "./utils.js";
 export interface TempCleanupOptions {
   dryRun: boolean;
   keepHours: number;
+  verbose?: boolean;
 }
 
 /**
  * Clean up all temporary CDK output directories
  */
 export async function cleanupTempDirectories(options: TempCleanupOptions): Promise<void> {
-  const { dryRun, keepHours } = options;
+  const { dryRun, keepHours, verbose } = options;
   const tmpdir = os.tmpdir();
 
   console.log(`Scanning ${tmpdir}`);
@@ -25,28 +26,76 @@ export async function cleanupTempDirectories(options: TempCleanupOptions): Promi
     return;
   }
 
+  if (verbose) {
+    console.log(`Found ${directories.length} temporary CDK directory(ies)\n`);
+  }
+
   let totalCleaned = 0;
   let totalSize = 0;
+  const protectedDirs: Array<{ path: string; reason: string }> = [];
+  const dirsToDelete: Array<{ path: string; size: number }> = [];
 
   for (const dir of directories) {
     try {
       // Check if directory should be protected by age
-      if (await shouldProtectDirectory(dir, keepHours)) {
+      const protectionReason = await getProtectionReason(dir, keepHours);
+      if (protectionReason) {
+        if (verbose) {
+          protectedDirs.push({ path: dir, reason: protectionReason });
+        }
         continue;
       }
 
       // Calculate size before deletion
       const size = await calculateSize(dir);
       totalSize += size;
-
-      if (!dryRun) {
-        await fs.rm(dir, { recursive: true, force: true });
-      }
+      dirsToDelete.push({ path: dir, size });
 
       totalCleaned++;
-    } catch {
-      // Silently continue on error
+    } catch (error) {
+      if (verbose) {
+        console.warn(
+          `Warning: Failed to process ${dir}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
       continue;
+    }
+  }
+
+  if (verbose && protectedDirs.length > 0) {
+    console.log("Protected directories:");
+    for (const item of protectedDirs) {
+      console.log(`  ⊘ ${path.basename(item.path)} - ${item.reason}`);
+    }
+    console.log("");
+  }
+
+  if (verbose && dirsToDelete.length > 0) {
+    console.log("Directories to delete:");
+    for (const item of dirsToDelete) {
+      console.log(`  ✓ ${path.basename(item.path)} (${formatSize(item.size)})`);
+    }
+    console.log("");
+  }
+
+  if (!dryRun && dirsToDelete.length > 0) {
+    if (verbose) {
+      console.log("Deleting directories:");
+    }
+    for (const item of dirsToDelete) {
+      try {
+        if (verbose) {
+          console.log(`  → Deleting ${path.basename(item.path)}...`);
+        }
+        await fs.rm(item.path, { recursive: true, force: true });
+      } catch (error) {
+        console.warn(
+          `Warning: Failed to delete ${item.path}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    if (verbose) {
+      console.log("");
     }
   }
 
@@ -90,18 +139,23 @@ async function findTempDirectories(): Promise<string[]> {
 }
 
 /**
- * Check if directory should be protected based on age
+ * Get the reason why a directory should be protected from deletion
+ * Returns null if not protected
  */
-async function shouldProtectDirectory(dirPath: string, keepHours: number): Promise<boolean> {
+async function getProtectionReason(dirPath: string, keepHours: number): Promise<string | null> {
   if (keepHours <= 0) {
-    return false;
+    return null;
   }
 
   try {
     const stats = await fs.stat(dirPath);
     const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
-    return ageHours <= keepHours;
+    if (ageHours <= keepHours) {
+      return `modified within last ${keepHours} hour(s)`;
+    }
   } catch {
-    return false;
+    return null;
   }
+
+  return null;
 }

--- a/src/temp-cleanup.ts
+++ b/src/temp-cleanup.ts
@@ -73,41 +73,15 @@ export async function cleanupTempDirectories(options: TempCleanupOptions): Promi
   const totalCleaned = dirsToDelete.length;
   const totalSize = dirsToDelete.reduce((sum, item) => sum + item.size, 0);
 
-  if (verbose && protectedDirs.length > 0) {
-    console.log("Protected directories:");
-    for (const item of protectedDirs) {
-      console.log(`  ⊘ ${path.basename(item.path)} - ${item.reason}`);
-    }
-    console.log("");
+  // Display verbose information
+  if (verbose) {
+    displayProtectedDirectories(protectedDirs);
+    displayDirectoriesToDelete(dirsToDelete);
   }
 
-  if (verbose && dirsToDelete.length > 0) {
-    console.log("Directories to delete:");
-    for (const item of dirsToDelete) {
-      console.log(`  ✓ ${path.basename(item.path)} (${formatSize(item.size)})`);
-    }
-    console.log("");
-  }
-
+  // Delete directories
   if (!dryRun && dirsToDelete.length > 0) {
-    if (verbose) {
-      console.log("Deleting directories:");
-    }
-    for (const item of dirsToDelete) {
-      try {
-        if (verbose) {
-          console.log(`  → Deleting ${path.basename(item.path)}...`);
-        }
-        await fs.rm(item.path, { recursive: true, force: true });
-      } catch (error) {
-        console.warn(
-          `Warning: Failed to delete ${item.path}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    }
-    if (verbose) {
-      console.log("");
-    }
+    await deleteDirectoriesWithProgress(dirsToDelete, verbose ?? false);
   }
 
   if (totalCleaned === 0) {
@@ -168,4 +142,63 @@ async function checkProtection(dirPath: string, keepHours: number): Promise<Prot
   }
 
   return { isProtected: false };
+}
+
+/**
+ * Display protected directories in verbose mode
+ */
+function displayProtectedDirectories(dirs: Array<{ path: string; reason: string }>): void {
+  if (dirs.length === 0) {
+    return;
+  }
+
+  console.log("Protected directories:");
+  for (const item of dirs) {
+    console.log(`  ⊘ ${path.basename(item.path)} - ${item.reason}`);
+  }
+  console.log("");
+}
+
+/**
+ * Display directories to be deleted in verbose mode
+ */
+function displayDirectoriesToDelete(dirs: Array<{ path: string; size: number }>): void {
+  if (dirs.length === 0) {
+    return;
+  }
+
+  console.log("Directories to delete:");
+  for (const item of dirs) {
+    console.log(`  ✓ ${path.basename(item.path)} (${formatSize(item.size)})`);
+  }
+  console.log("");
+}
+
+/**
+ * Delete directories with optional verbose progress output
+ */
+async function deleteDirectoriesWithProgress(
+  dirs: Array<{ path: string }>,
+  verbose: boolean,
+): Promise<void> {
+  if (verbose) {
+    console.log("Deleting directories:");
+  }
+
+  for (const item of dirs) {
+    try {
+      if (verbose) {
+        console.log(`  → Deleting ${path.basename(item.path)}...`);
+      }
+      await fs.rm(item.path, { recursive: true, force: true });
+    } catch (error) {
+      console.warn(
+        `Warning: Failed to delete ${item.path}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  if (verbose) {
+    console.log("");
+  }
 }

--- a/src/temp-cleanup.ts
+++ b/src/temp-cleanup.ts
@@ -9,6 +9,11 @@ export interface TempCleanupOptions {
   verbose?: boolean;
 }
 
+interface ProtectionResult {
+  isProtected: boolean;
+  reason?: string;
+}
+
 /**
  * Clean up all temporary CDK output directories
  */
@@ -30,37 +35,43 @@ export async function cleanupTempDirectories(options: TempCleanupOptions): Promi
     console.log(`Found ${directories.length} temporary CDK directory(ies)\n`);
   }
 
-  let totalCleaned = 0;
-  let totalSize = 0;
-  const protectedDirs: Array<{ path: string; reason: string }> = [];
-  const dirsToDelete: Array<{ path: string; size: number }> = [];
+  const analysisResults = await Promise.all(
+    directories.map(async (dir) => {
+      try {
+        const protection = await checkProtection(dir, keepHours);
+        const size = await calculateSize(dir);
 
-  for (const dir of directories) {
-    try {
-      // Check if directory should be protected by age
-      const protectionReason = await getProtectionReason(dir, keepHours);
-      if (protectionReason) {
+        return {
+          path: dir,
+          size,
+          protection,
+        };
+      } catch (error) {
         if (verbose) {
-          protectedDirs.push({ path: dir, reason: protectionReason });
+          console.warn(
+            `Warning: Failed to process ${dir}: ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
-        continue;
+        return null;
       }
+    }),
+  );
 
-      // Calculate size before deletion
-      const size = await calculateSize(dir);
-      totalSize += size;
-      dirsToDelete.push({ path: dir, size });
+  const validResults = analysisResults.filter(
+    (result): result is { path: string; size: number; protection: ProtectionResult } =>
+      result !== null,
+  );
 
-      totalCleaned++;
-    } catch (error) {
-      if (verbose) {
-        console.warn(
-          `Warning: Failed to process ${dir}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-      continue;
-    }
-  }
+  const protectedDirs = validResults
+    .filter((result) => result.protection.isProtected)
+    .map(({ path, protection }) => ({ path, reason: protection.reason! }));
+
+  const dirsToDelete = validResults
+    .filter((result) => !result.protection.isProtected)
+    .map(({ path, size }) => ({ path, size }));
+
+  const totalCleaned = dirsToDelete.length;
+  const totalSize = dirsToDelete.reduce((sum, item) => sum + item.size, 0);
 
   if (verbose && protectedDirs.length > 0) {
     console.log("Protected directories:");
@@ -139,23 +150,22 @@ async function findTempDirectories(): Promise<string[]> {
 }
 
 /**
- * Get the reason why a directory should be protected from deletion
- * Returns null if not protected
+ * Check if a directory should be protected from deletion
  */
-async function getProtectionReason(dirPath: string, keepHours: number): Promise<string | null> {
+async function checkProtection(dirPath: string, keepHours: number): Promise<ProtectionResult> {
   if (keepHours <= 0) {
-    return null;
+    return { isProtected: false };
   }
 
   try {
     const stats = await fs.stat(dirPath);
     const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
     if (ageHours <= keepHours) {
-      return `modified within last ${keepHours} hour(s)`;
+      return { isProtected: true, reason: `modified within last ${keepHours} hour(s)` };
     }
   } catch {
-    return null;
+    return { isProtected: false };
   }
 
-  return null;
+  return { isProtected: false };
 }

--- a/test-cdk/scripts/test-basic.ts
+++ b/test-cdk/scripts/test-basic.ts
@@ -36,11 +36,11 @@ console.log("   ✓ Added asset.unused/ and user-file.txt");
 
 // Step 3: Dry run
 console.log("\n3. Running cdk-agc in dry-run mode...");
-execSync(`node ${CLI} -o ${CDK_OUT} -d`, { stdio: "inherit" });
+execSync(`node ${CLI} -o ${CDK_OUT} -d -v`, { stdio: "inherit" });
 
 // Step 4: Actual cleanup
 console.log("\n4. Running actual cleanup...");
-execSync(`node ${CLI} -o ${CDK_OUT}`, { stdio: "inherit" });
+execSync(`node ${CLI} -o ${CDK_OUT} -v`, { stdio: "inherit" });
 
 // Step 5: Verify
 console.log("\n5. Verifying cleanup...");

--- a/test-cdk/scripts/test-keep-hours.ts
+++ b/test-cdk/scripts/test-keep-hours.ts
@@ -35,7 +35,7 @@ console.log("   ✓ Added asset.recent123/");
 
 // Step 3: Cleanup with --keep-hours 1
 console.log("\n3. Running cleanup with --keep-hours 1...");
-execSync(`node ${CLI} -o ${CDK_OUT} -k 1`, { stdio: "inherit" });
+execSync(`node ${CLI} -o ${CDK_OUT} -k 1 -v`, { stdio: "inherit" });
 
 // Step 4: Verify recent asset still exists
 console.log("\n4. Verifying recent asset is protected...");
@@ -50,7 +50,7 @@ if (hasRecentAsset) {
 
 // Step 5: Cleanup without protection
 console.log("\n5. Running cleanup without --keep-hours...");
-execSync(`node ${CLI} -o ${CDK_OUT}`, { stdio: "inherit" });
+execSync(`node ${CLI} -o ${CDK_OUT} -v`, { stdio: "inherit" });
 
 // Step 6: Verify recent asset is now deleted
 console.log("\n6. Verifying recent asset is now deleted...");

--- a/test-cdk/scripts/test-multiple.ts
+++ b/test-cdk/scripts/test-multiple.ts
@@ -50,7 +50,7 @@ console.log("   ✓ Added asset.old123/");
 
 // Step 5: Cleanup
 console.log("\n5. Running cleanup...");
-execSync(`node ${CLI} -o ${CDK_OUT}`, { stdio: "inherit" });
+execSync(`node ${CLI} -o ${CDK_OUT} -v`, { stdio: "inherit" });
 
 // Step 6: Verify old asset was removed
 console.log("\n6. Verifying old asset was removed...");


### PR DESCRIPTION
## Summary

Adds a new `-v/--verbose` flag that provides detailed operation information during cleanup.

### What's New

- **Verbose mode** (`-v, --verbose`): Shows detailed step-by-step information about:
  - Asset collection from `*.assets.json` files
  - Total assets found vs referenced assets
  - Protected assets with reasons (referenced or within keep-hours)
  - Asset deletion progress
  - Docker image search and removal details
  - Temporary directory cleanup details

### Example Output

```bash
$ npx cdk-agc -v

Scanning /path/to/cdk.out

Collecting referenced assets from *.assets.json files...
Found 12 referenced asset(s)

Found 15 total asset(s) in directory
Analyzing assets for deletion candidates...

Protected assets:
  ⊘ asset.abc123def456 (500 MB) - referenced in *.assets.json
  ⊘ asset.recent12345 (100 MB) - modified within last 1 hour(s)

Found 3 unused item(s):
  - asset.old123 (200 MB)
  - asset.old456 (150 MB)
  - asset.old789 (100 MB)

Deleting assets:
  → Deleting asset.old123...
  → Deleting asset.old456...
  → Deleting asset.old789...

Searching for Docker images...
Using Docker command: docker

Found 2 Docker image(s) to remove
...
```

### Use Cases

- **Debugging**: Understand exactly what the tool is doing and why
- **CI/CD**: Get detailed logs for pipeline troubleshooting
- **Transparency**: See which assets are protected and why
- **Verification**: Confirm the tool is working as expected before running without dry-run

### Changes

- Added `-v, --verbose` CLI option
- Implemented verbose logging in:
  - Asset cleanup (src/asset-cleanup.ts)
  - Docker image cleanup (src/docker-cleanup.ts)
  - Temporary directory cleanup (src/temp-cleanup.ts)
- Added comprehensive tests for verbose mode
- Updated README with usage examples and documentation

## Test plan

- [x] All existing tests pass (77/77)
- [x] New tests added for verbose mode
- [x] TypeScript compilation succeeds
- [x] Build succeeds (pnpm vp pack)
- [x] Manual testing of verbose output
- [x] Help text includes new option

🤖 Generated with [Claude Code](https://claude.com/claude-code)
