### PR TITLE
ci: add Dependabot config for npm and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot version updates.
+#
+# Commit-message prefixes are chosen against this repo's semantic-release
+# rules (.releaserc.json, default commit-analyzer): `chore(...)` / `ci(...)`
+# do NOT cut a release, which is deliberate — the runtime dep uses a caret
+# range, so users already pick up newer versions on install; a lockfile/range
+# bump only affects dev + CI. All prefixes are in pr-title-check.yml's
+# allowed types.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` (version-update config; previously absent), mirroring go-to-k/cdkd#2486:

- **npm** (pnpm-lock.yaml), weekly (Mon, Asia/Tokyo): a `dev-dependencies` group (one PR for all devDependencies), individual PRs for runtime deps (currently just `commander`), `open-pull-requests-limit: 10`.
- **github-actions**, weekly, all actions grouped into one PR.

Commit-message prefixes (`chore(deps)` / `chore(deps-dev)` / `ci(deps)`) are allowed types in `pr-title-check.yml` and do not trigger a semantic-release release (default commit-analyzer releases only on `feat` / `fix` / `perf` / breaking) — deliberate, since the runtime dep uses a caret range and a range/lockfile bump only affects dev + CI.

## Test plan

- Config validated against SchemaStore's `dependabot-2.0.json` with ajv: valid
- Live behavior cannot be exercised pre-merge — Dependabot only reads the file from the default branch; the first scheduled run after merge is the real confirmation.
